### PR TITLE
Add neoclassical growth model example

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ The [examples folder](https://github.com/matthieugomez/EconPDEs.jl/tree/master/e
 - *Heterogeneous Agent Models*: He Krishnamurthy (2013), Brunnermeir Sannikov (2013), Garleanu Panageas (2015), Di Tella (2017), Haddad (JMP)
 - *Consumption with Borrowing Constraint*: Wang Wang Yang (2016), Achdou Han Lasry Lions Moll (2018)
 - *Investment with Borrowing Constraint*: Bolton Chen Wang (2009)
+- *Growth Model*: deterministic neoclassical (Ramsey) growth model, on a grid centered on its closed-form steady state
 
 ## Installation
 The package is registered in the [`General`](https://github.com/JuliaRegistries/General) registry and so can be installed at the REPL with `] add EconPDEs`.

--- a/examples/GrowthModel/NeoclassicalGrowthModel.jl
+++ b/examples/GrowthModel/NeoclassicalGrowthModel.jl
@@ -1,0 +1,58 @@
+using EconPDEs
+
+# Deterministic neoclassical (Ramsey–Cass–Koopmans) growth model.
+#
+# A representative household chooses consumption to solve
+#     max ∫₀^∞ e^{-ρt} u(c) dt    s.t.    k̇ = A k^α - δ k - c
+# with CRRA utility u(c) = c^{1-γ} / (1 - γ).
+#
+# The value function v(k) solves the HJB equation
+#     ρ v(k) = max_c u(c) + v'(k) (A k^α - δ k - c)
+# with the first-order condition u'(c) = v'(k), i.e. c = v'(k)^{-1/γ}.
+#
+# Since the drift k̇ can be of either sign, the first derivative is upwinded:
+# the forward difference is used where the implied drift is positive, the
+# backward difference where it is negative, and the consumption that sets the
+# drift to zero at the steady state otherwise (Achdou–Han–Lasry–Lions–Moll).
+
+Base.@kwdef struct NeoclassicalGrowthModel
+    A::Float64 = 0.5    # total factor productivity
+    α::Float64 = 0.3    # capital share
+    δ::Float64 = 0.05   # depreciation rate
+    ρ::Float64 = 0.05   # discount rate
+    γ::Float64 = 2.0    # relative risk aversion
+end
+
+function (m::NeoclassicalGrowthModel)(state::NamedTuple, value::NamedTuple)
+    (; A, α, δ, ρ, γ) = m
+    (; k) = state
+    (; v, vk_up, vk_down) = value
+    # upwind the first derivative on the sign of the drift
+    cF = max(vk_up, eps())^(-1 / γ)
+    μF = A * k^α - δ * k - cF
+    cB = max(vk_down, eps())^(-1 / γ)
+    μB = A * k^α - δ * k - cB
+    if μF > 0
+        c, vk, μk = cF, vk_up, μF
+    elseif μB < 0
+        c, vk, μk = cB, vk_down, μB
+    else
+        # at the steady state the household consumes its net output
+        c, vk, μk = A * k^α - δ * k, vk_up, 0.0
+    end
+    vt = - (c^(1 - γ) / (1 - γ) + μk * vk - ρ * v)
+    return (; vt)
+end
+
+m = NeoclassicalGrowthModel()
+(; A, α, δ, ρ, γ) = m
+
+# Closed-form steady-state capital: f'(k) = ρ + δ ⟹ α A k^{α-1} = ρ + δ
+kstar = (α * A / (ρ + δ))^(1 / (1 - α))
+
+stategrid = OrderedDict(:k => range(0.1 * kstar, 5 * kstar, length = 1000))
+# initial guess: value of consuming gross output forever (monotone increasing in k,
+# so that v'(k) > 0 and the implied consumption v'(k)^{-1/γ} stays well-defined)
+yend = OrderedDict(:v => [(A * k^α)^(1 - γ) / (1 - γ) / ρ for k in stategrid[:k]])
+result = pdesolve(m, stategrid, yend)
+@assert result.residual_norm <= 1e-5

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,6 +13,10 @@ for x in (:BoltonChenWang, )
 	@testset "$x" begin include("../examples/InvestmentProblem/$(x).jl") end
 end
 
+for x in (:NeoclassicalGrowthModel, )
+	@testset "$x" begin include("../examples/GrowthModel/$(x).jl") end
+end
+
 for x in (:Leland, )
 	@testset "$x" begin include("../examples/OptimalStoppingTime/$(x).jl") end
 end


### PR DESCRIPTION
Adds `examples/GrowthModel/NeoclassicalGrowthModel.jl`, solving the deterministic neoclassical (Ramsey) growth model with `pdesolve` and an upwind first-derivative scheme. The grid is centered on the closed-form steady-state capital $k^\*=(\alpha A/(\rho+\delta))^{1/(1-\alpha)}$. Also wires the example into the test suite and lists it in the README.

Closes #28.