### PR TITLE
Use NonlinearSolve and add monotonicity diagnostics

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "EconPDEs"
 uuid = "a3315474-fad9-5060-8696-cee5f38a87b7"
-version = "1.4.0"
+version = "1.5.0"
 
 [deps]
 BlockArrays = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
@@ -8,6 +8,7 @@ BlockBandedMatrices = "ffab5731-97b5-5995-9138-79e8c1846df0"
 FiniteDiff = "6a86dc24-6348-571c-b903-95158fe2bd41"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 NLsolve = "2774e3e8-f4cf-5e23-947b-6d7e65073b56"
+NonlinearSolve = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
@@ -18,14 +19,16 @@ BlockBandedMatrices = "0.7, 0.8, 0.9, 0.10, 0.11, 0.12, 0.13"
 FiniteDiff = "2"
 LinearAlgebra = "1"
 NLsolve = "4"
+NonlinearSolve = "4.20"
 OrderedCollections = "1"
-julia = "1.7"
+julia = "1.10"
 
 [extras]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 InfinitesimalGenerators = "2fce0c6f-5f0b-5c85-85c9-2ffe1d5ee30d"
+Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Roots ="f2b01f46-fcfa-551c-844a-d8ac1e96c665"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Distributions", "InfinitesimalGenerators", "Roots"]
+test = ["Test", "Distributions", "InfinitesimalGenerators", "Roots", "Logging"]

--- a/README.md
+++ b/README.md
@@ -1,90 +1,127 @@
 [![Build status](https://github.com/matthieugomez/EconPDEs.jl/workflows/CI/badge.svg)](https://github.com/matthieugomez/EconPDEs.jl/actions)
 [![Coverage Status](http://codecov.io/github/matthieugomez/EconPDEs.jl/coverage.svg?branch=main)](http://codecov.io/github/matthieugomez/EconPDEs.jl/?branch=main)
 
+# EconPDEs.jl
 
-This package provides the function `pdesolve` that solves (system of) nonlinear ODEs/PDEs arising in economic models (i.e. PDEs arising from HJB equations). It is:
+`EconPDEs.jl` solves nonlinear ODEs and PDEs that arise in economic models, especially Hamilton-Jacobi-Bellman equations. You write the local equation; the package supplies finite-difference derivatives, upwinding, sparse Jacobians, and pseudo-transient Newton iteration.
 
-- robust: upwinding + fully implicit time stepping (see [here](https://github.com/matthieugomez/EconPDEs.jl/blob/main/examples/details.pdf))
-- fast: sparse matrices + Newton acceleration
-- simple-to-use
+Use it when an economic model gives a stationary or time-dependent HJB on a grid, possibly with several value functions and several state variables.
 
-# A Simple Example
+## Installation
 
-Let us solve the PDE for the price-dividend ratio in the Long Run Risk model with time-varying drift:
-<!-- 
-1 - \rho V + (1 - \frac{1}{\psi})(\mu - \frac{1}{2}\gamma \vartheta)V + \theta_\mu(\overline{\mu} - \mu) \partial_\mu V + \frac{1}{2}\frac{\frac{1}{\psi}-\gamma}{1-\frac{1}{\psi}}\nu_\mu^2 \vartheta \frac{(\partial_\mu V)^2}{V} + \frac{1}{2}\nu_\mu^2 \vartheta \partial_{\mu\mu}V  + \partial_t V  = 0
--->
-<img src="img/by.png">
+The package is registered in the Julia `General` registry:
+
+```julia
+] add EconPDEs
+```
+
+Current versions require Julia 1.10 or later.
+
+## Quickstart
+
+The main function is `pdesolve`. A stationary problem needs a PDE function, a state grid, and an initial guess:
 
 ```julia
 using EconPDEs
 
-# Define a discretized state space
-# An OrderedDict in which each key corresponds to a state variable
-# Grids can be non-homogeneous
-stategrid = OrderedDict(:μ => range(-0.05, 0.1, length = 500))
+grid = OrderedDict(:x => range(-1.0, 1.0, length = 100))
+guess = OrderedDict(:v => zeros(length(grid[:x])))
 
-# Define an initial guess for the value functions
-# An OrderedDict in which each key corresponds to a value function to solve for, 
-# specified as an array with as many dimensions as there are state variables
-solend = OrderedDict(:V => ones(500))
+function hjb(state::NamedTuple, y::NamedTuple)
+    x = state.x
+    v, vx_up, vx_down, vxx = y.v, y.vx_up, y.vx_down, y.vxx
 
-# Define a function that encodes the PDE. 
-# The function takes three arguments:
-# 1. A named tuple giving the current value of the state. 
-# 2. A named tuple giving the value function(s) (as well as its derivatives)
-# at the current value of the state. 
-# 3. (Optional) Current time t
-# It must return a named tuple with the time derivatives
-function f(state::NamedTuple, sol::NamedTuple)
-           μbar = 0.018 ; ϑ = 0.00073 ; θμ = 0.252 ; νμ = 0.528 ; ρ = 0.025 ; ψ = 1.5 ; γ = 7.5
-           μ = state.μ
-           V, Vμ_up, Vμ_down, Vμμ = sol.V, sol.Vμ_up, sol.Vμ_down, sol.Vμμ
-           # note that pdesolve will directly compute the derivatives of the valuefunction.
-           # up and down correspond to the upward and downard derivative obtained by first difference
-           Vμ = (μ <= μbar) ? Vμ_up : Vμ_down
-           Vt = - (1  - ρ * V + (1 - 1 / ψ) * (μ - 0.5 * γ * ϑ) * V + θμ * (μbar - μ) * Vμ +
-           0.5 * νμ^2 * ϑ * Vμμ  + 0.5 * (1 / ψ - γ) / (1- 1 / ψ) * νμ^2 *  ϑ * Vμ^2/V)
-           (Vt = Vt,)
+    μx = -x
+    vx = μx >= 0 ? vx_up : vx_down
+
+    vt = -(x^2 + μx * vx + 0.05 * vxx - 0.04 * v)
+    return (; vt)
 end
 
-# The function `pdesolve` takes four arguments:
-# 1. the function encoding the PDE
-# 2. the discretized state space
-# 3. the terminal value function
-# 4. (Optional) a time grid
-ys, residual_norms = pdesolve(f, stategrid, solend, range(0, 1000, length = 100))
-
-# To solve directly for the stationary solution, 
-# i.e. the solution of the PDE with ∂tV = 0,
-# simply omit the time grid
-y, residual_norm =  pdesolve(f, stategrid, solend)
+result = pdesolve(hjb, grid, guess; verbose = false)
+value = result.zero[:v]
+residual_norm = result.residual_norm
 ```
-More complicated ODEs / PDES (including PDE with two state variables or systems of multiple PDEs) can be found in the `examples` folder. 
 
+For a time-dependent problem, pass an increasing time grid as the fourth argument:
 
+```julia
+result = pdesolve(hjb, grid, guess, range(0, 100, length = 50))
+```
 
-# Boundary Conditions
-When solving a PDE using a finite scheme approach, one needs to specify the value of the solution *outside* the grid ("ghost node") to construct the second derivative and, in some cases, the first derivative *at* the boundary. 
+## Model Conventions
 
-By default, the values at the ghost node is assumed to equal the value at the boundary node (reflecting boundaries). Specify different values for values at the ghost node using the option `bc` (see [BoltonChenWang.jl](https://github.com/matthieugomez/EconPDEs.jl/blob/main/examples/InvestmentProblem/BoltonChenWang.jl) for an example).
+The PDE function has the form
 
-## EconPDEs v1.0.0
-The 1.0 release has the following set of breaking changes:
+```julia
+f(state::NamedTuple, y::NamedTuple) -> NamedTuple
+```
 
-1. The first argument of pdesolve (the function encoding the PDE) must accept directional first derivatives and it must return a named tuple of time derivatives
-2. The fourth argument of pdesolve (the time grid) must be in increasing order
-3. pdesolve now returns a type with fieldnames zero (for the solution) and residual_norm (for the norm of residuals)
+`state` gives the current grid point. `y` gives each unknown function and its finite-difference derivatives at that point. If the unknown is `v` and the state is `x`, then `y` contains:
 
-See the updated examples for the new syntax.
+- `v`: value of the function.
+- `vx_up` and `vx_down`: forward and backward first derivatives.
+- `vxx`: second derivative.
+
+With several states, cross derivatives are also available, such as `vxy`, `vxy_up`, and `vxy_down`. The PDE function must return one time derivative for each unknown; for `v`, return `vt`.
+
+For time-dependent equations, the PDE function may also accept time:
+
+```julia
+f(state::NamedTuple, y::NamedTuple, t) -> NamedTuple
+```
+
+## Endogenous Choices and Borrowing Constraints
+
+Borrowing constraints and other endogenous state constraints are usually part of the PDE. Put assets, wealth, or the constrained object on the state grid. Then compute the policy inside the PDE function, form the state drift, and choose the upwind derivative from the sign of that drift.
+
+For example, in a consumption-saving problem with asset state `a`, compute consumption from the marginal value of assets, form the asset drift `μa`, and then use `va_up` or `va_down` depending on the sign of `μa`. At the borrowing limit, impose feasibility directly: prevent the drift from moving below the lower asset bound, or impose the boundary derivative implied by the constraint.
+
+The `y̲` and `ȳ` keywords have a different role. They impose bounds on the unknown function itself in a variational inequality, as in optimal stopping. They are not the right tool for an ordinary borrowing constraint on a state variable or policy choice.
+
+See [WangWangYang.jl](examples/ConsumptionProblem/WangWangYang.jl), [AchdouHanLasryLionsMoll_Diffusion.jl](examples/ConsumptionProblem/AchdouHanLasryLionsMoll_Diffusion.jl), and [BoltonChenWang.jl](examples/InvestmentProblem/BoltonChenWang.jl) for examples.
+
+## Boundary Conditions
+
+Finite-difference schemes need ghost-node values outside the grid to construct derivatives at the boundary. By default, `EconPDEs.jl` uses reflecting boundaries: the ghost-node value equals the boundary-node value, so the first derivative is zero beyond the boundary.
+
+Use the `bc` keyword to impose a different boundary derivative:
+
+```julia
+pdesolve(f, grid, guess; bc = OrderedDict(:vx => (0.0, 1.0)))
+```
 
 ## Optimal Stopping
-Optimal stopping problems are also supported, as exemplified in [Leland.jl](examples/OptimalStoppingTime/Leland.jl). These problems are solved with "HJB variational inequality" (HJBVI), i.e.:
+
+Optimal stopping problems are supported through HJB variational inequalities. For a payoff `S(x)`, the HJBVI is:
 
 <img src="img/hjbvi.png">
 
-where `S(x)` is the value of exercising the option. Notice the traditional "value matching" (`S(x̲)=v(x̲)`) and "smooth pasting" (`S'(x̲)=v'(x̲)`) conditions are implied in the HJBVI formulation. See [the deck of notes from Ben Moll on stopping time problems](https://benjaminmoll.com/codes/) for more details. The `S(x)` can be provided to the solver as a vector defined on the grid via the keyword `y̲` (or `ȳ` as the upper bound for cost minimization problems).
+Pass the exercise payoff as a lower bound with `y̲`; use `ȳ` for upper bounds in minimization problems. This formulation implies the usual value-matching and smooth-pasting conditions. See [Leland.jl](examples/OptimalStoppingTime/Leland.jl) for a working example and Ben Moll's [notes on stopping time problems](https://benjaminmoll.com/codes/) for background.
 
+Internally, these bounded problems are mixed complementarity problems and use `NLsolve.mcpsolve`. Ordinary nonlinear PDE solves use `NonlinearSolve.jl`.
+
+## Diagnostics and Solver Backend
+
+For ordinary PDE solves, `EconPDEs.jl` constructs a sparse colored finite-difference Jacobian and passes it to `NonlinearSolve.jl`. The default nonlinear method is Newton's method:
+
+```julia
+pdesolve(f, grid, guess; method = :newton)
+```
+
+The trust-region solver is also available:
+
+```julia
+pdesolve(f, grid, guess; method = :trust_region)
+```
+
+As an opt-in diagnostic, `pdesolve` can check the sparse residual Jacobian for monotonicity violations:
+
+```julia
+pdesolve(f, grid, guess; check_monotonicity = true)
+```
+
+This checks the effective neighbor weights in the fully assembled equation, after endogenous policies, risk adjustments, and nonlinear terms are included. Upwinding on the raw state drift is only a shortcut that is guaranteed to work for a linear drift term. Under the package's `vt = -(...)` convention, a positive same-variable spatial off-diagonal entry usually means that an `_up` or `_down` stencil was chosen with the wrong sign. For transformed equations or endogenous-control problems, treat the warning as a debugging diagnostic rather than a proof that the economic upwind rule is wrong. Adjust `monotonicity_tol` (default `1e-6`) and `monotonicity_max_warnings` to tune it.
 
 # Examples
 The [examples folder](https://github.com/matthieugomez/EconPDEs.jl/tree/master/examples)  solves a variety of models:
@@ -96,9 +133,6 @@ The [examples folder](https://github.com/matthieugomez/EconPDEs.jl/tree/master/e
 - *Investment with Borrowing Constraint*: Bolton Chen Wang (2009)
 - *Growth Model*: deterministic neoclassical (Ramsey) growth model, on a grid centered on its closed-form steady state
 
-## Installation
-The package is registered in the [`General`](https://github.com/JuliaRegistries/General) registry and so can be installed at the REPL with `] add EconPDEs`.
-
 ## Citation
 If you use EconPDEs.jl in your work, please cite it. You can use the "Cite this repository" button on the [GitHub page](https://github.com/matthieugomez/EconPDEs.jl) (generated from [`CITATION.cff`](CITATION.cff)), or the following BibTeX entry:
 
@@ -109,4 +143,3 @@ If you use EconPDEs.jl in your work, please cite it. You can use the "Cite this 
   url    = {https://github.com/matthieugomez/EconPDEs.jl},
 }
 ```
-

--- a/examples/AssetPricing/BansalYaron.jl
+++ b/examples/AssetPricing/BansalYaron.jl
@@ -63,9 +63,9 @@ m = BansalYaronModel()
 μn = 30
 vn = 30
 μdistribution = Normal(m.μbar,  sqrt(m.νμ^2 * m.vbar / (2 * m.κμ)))
-μs = range(quantile(μdistribution, 0.025), quantile(μdistribution, 0.975), length = μn)
+μs = range(quantile(μdistribution, 0.01), quantile(μdistribution, 0.975), length = μn)
 νdistribution = Gamma(2 * m.κv * m.vbar / m.νv^2, m.νv^2 / (2 * m.κv))
-vs = range(quantile(νdistribution, 0.025), quantile(νdistribution, 0.975), length = vn)
+vs = range(quantile(νdistribution, 0.0), quantile(νdistribution, 0.975), length = vn)
 stategrid = OrderedDict(:μ => μs, :v => vs)
 
 ## define initial guess

--- a/examples/AssetPricing/CampbellCochrane.jl
+++ b/examples/AssetPricing/CampbellCochrane.jl
@@ -40,8 +40,10 @@ function (m::CampbellCochraneModel)(state::NamedTuple, y::NamedTuple)
     sbar = log(Sbar)
     λ = 1 / Sbar * sqrt(1 - 2 * (s - sbar)) - 1
     μs = - κs * (s - sbar)
-    ps = (μs >= 0) ? ps_up : ps_down
     σs = λ * σ
+    # Pricing uses the risk-adjusted drift, not the physical drift of surplus consumption.
+    μs_effective = μs + σs * (σ - γ * (σ + σs))
+    ps = (μs_effective >= 0) ? ps_up : ps_down
     σp = ps / p * σs
     μp = ps / p * μs + 0.5 * pss / p * σs^2
 
@@ -68,4 +70,3 @@ result = pdesolve(m, stategrid, yend)
 # stategrid = initialize_stategrid(m)
 # yend = OrderedDict(:p => ones(length(stategrid[:s])))
 # y, result, distance = pdesolve(m, stategrid, yend)
-

--- a/examples/AssetPricing/DiTella.jl
+++ b/examples/AssetPricing/DiTella.jl
@@ -61,7 +61,7 @@ function (m::DiTellaModel)(state::NamedTuple, y::NamedTuple)
   σA = κ / γ + (1 - γ) / (γ * (ψ - 1)) * σpA
   νA = κν / γ
   σB = κ / γ + (1 - γ) / (γ * (ψ - 1)) * σpB
-  
+
   # Interest rate r
   μX = x * (1 - x) * ((σA * κ + νA * κν - 1 / pA - τ) - (σB * κ -  1 / pB + τ * x / (1 - x)) - (σA - σB) * (σ + σp))
 

--- a/examples/AssetPricing/Haddad.jl
+++ b/examples/AssetPricing/Haddad.jl
@@ -35,7 +35,7 @@ function (m::HaddadModel)(state::NamedTuple, y::NamedTuple)
   μv = κv * (vbar - v)
 
   pμ = (μμ >= 0) ? pμ_up : pμ_down
-  pv = (νμ >= 0) ? pv_up : pv_down 
+  pv = (μv >= 0) ? pv_up : pv_down
   σv = νv * sqrt(v) 
   σp_Zμ = pμ / p * σμ
   σp_Zv = pv / p * σv

--- a/examples/ConsumptionProblem/AchdouHanLasryLionsMoll_Diffusion.jl
+++ b/examples/ConsumptionProblem/AchdouHanLasryLionsMoll_Diffusion.jl
@@ -25,24 +25,33 @@ function (m::AchdouHanLasryLionsMollModel_Diffusion)(state::NamedTuple, value::N
     (; y, a) = state
     (; v, vy_up, vy_down, va_up, va_down, vyy, vya, vaa) = value
     μy = κy * (ybar - y)
+
+    # upwinding for income direction (easy because exogenous income drift)
     vy = (μy >= 0) ? vy_up : vy_down
 
-    va = va_up
-    iter = 0
-    @label start
-    va = max(va, eps())    
-    c = va^(-1 / γ)
-    μa = y + r * a - c
-    if (iter == 0) && (μa <= 0)
-        iter += 1
-        va = va_down
-        @goto start
-    end
-    # Borrowing Constraint
-    if (a ≈ amin) && (μa <= 0.0)
-        va = (y + r * a)^(-γ)
-        c = y + r * a
-        μa = 0.0
+    # upwinding for asset direction (harder because endogeneous asset drift)
+    va_up = max(va_up, eps())
+    c_up = va_up^(-1 / γ)
+    μa_up = y + r * a - c_up
+    if μa_up >= 0.0
+        va = va_up
+        c = c_up
+        μa = μa_up
+    else
+        va_down = max(va_down, eps())
+        c_down = va_down^(-1 / γ)
+        μa_down = y + r * a - c_down
+        if (μa_down <= 0.0) && (a > amin)
+            va = va_down
+            c = c_down
+            μa = μa_down
+        else
+            # If the two candidates straddle zero OR drift is negative at minimum asset threshold  
+            # (i.e. borrowing constraint), then, we must have drift μa = 0.
+            c = y + r * a
+            va = c^(-γ)
+            μa = 0.0
+        end
     end
     vt = - (c^(1 - γ) / (1 - γ) + μa * va + μy * vy + 0.5 * vyy * σy^2 - ρ * v)
     return (; vt)
@@ -66,3 +75,4 @@ result = pdesolve(m, stategrid, yend)
 # Check marginal value of wealth converges to 1.0 at infinity
 #b = ((m.r + (m.ρ - m.r)/m.γ))^(1/(1 - 1/m.γ))
 #pw = (result[:v] * (1-m.γ)).^(1/(1-m.γ)-1) .* result[:va] ./ b
+#@assert abs(pw - 1) <= 1e-5

--- a/examples/ConsumptionProblem/AchdouHanLasryLionsMoll_DiffusionTwoAssets.jl
+++ b/examples/ConsumptionProblem/AchdouHanLasryLionsMoll_DiffusionTwoAssets.jl
@@ -23,22 +23,51 @@ function (m::AchdouHanLasryLionsMoll_DiffusionTwoAssetsModel)(state::NamedTuple,
     (; y, a) = state
     (; v, vy_up, vy_down, va_up, va_down, vyy, vya, vaa) = value
     μy = κy * (ybar - y)
+
+    # upwinding for income direction (easy because exogenous income drift)
     vy = (μy >= 0) ? vy_up : vy_down
-    
-    va = va_up
-    iter = 0
-    @label start
-    va = max(va, eps())    
-    c = va^(-1 / γ)
-    k = (μR - r) / σR^2 * (- va / vaa)
-    k = clamp(k, 0.0, a - amin)
-    μa = y + r * a + (μR - r) * k - c
-    if (iter == 0) && (μa <= 0)
-        iter += 1
-        va = va_down
-        @goto start
+
+    # upwinding for asset direction (harder because endogeneous asset drift)
+    va_up = max(va_up, eps())
+    c_up = va_up^(-1 / γ)
+    k_up = (μR - r) / σR^2 * (-va_up / vaa)
+    k_up = clamp(k_up, 0.0, a - amin)
+    μa_up = y + r * a + (μR - r) * k_up - c_up
+    if μa_up >= 0.0
+        va = va_up
+        c = c_up
+        k = k_up
+        μa = μa_up
+    else
+        va_down = max(va_down, eps())
+        c_down = va_down^(-1 / γ)
+        k_down = (μR - r) / σR^2 * (-va_down / vaa)
+        k_down = clamp(k_down, 0.0, a - amin)
+        μa_down = y + r * a + (μR - r) * k_down - c_down
+        if (μa_down <= 0.0) && (a >= amin)
+            va = va_down
+            c = c_down
+            k = k_down
+            μa = μa_down
+        else
+            # If the two candidates straddle zero OR drift is negative at minimum asset threshold  
+            # (i.e. borrowing constraint), then, we must have drift μa = 0.
+            c = max(y + r * a, eps())
+            for _ in 1:30
+                va = c^(-γ)
+                k = (μR - r) / σR^2 * (-va / vaa)
+                k = clamp(k, 0.0, a - amin)
+                c = y + r * a + (μR - r) * k
+            end
+            va = max(c, eps())^(-γ)
+            k = (μR - r) / σR^2 * (-va / vaa)
+            k = clamp(k, 0.0, a - amin)
+            c = y + r * a + (μR - r) * k
+            μa = 0.0
+        end
     end
     σa = k * σR
+
     # There is no second derivative at 0 so just specify first order derivative
     if (a ≈ amin) && (μa <= 0.0)
         va = (y + r * a)^(-γ)
@@ -77,4 +106,3 @@ y, residual_norm = pdesolve(m, stategrid, yend)
 # # This happens ONLY if a >= 1000.0. Otherwise with 300 it does not work. 
 # b = ((m.r + (m.ρ - m.r)/m.γ - (1-m.γ) / (2 * m.γ) * (m.μR - m.r)^2 / (m.γ * m.σR^2)))^(1/(1 - 1/m.γ))
 # pw = (result[:v] * (1-m.γ)).^(1/(1-m.γ)-1) .* result[:va] ./ b
-

--- a/examples/ConsumptionProblem/AchdouHanLasryLionsMoll_TwoStates.jl
+++ b/examples/ConsumptionProblem/AchdouHanLasryLionsMoll_TwoStates.jl
@@ -26,43 +26,55 @@ function (m::AchdouHanLasryLionsMoll_TwoStatesModel)(state::NamedTuple, value::N
     (; a) = state
     (; vl, vla_up, vla_down, vh, vha_up, vha_down) = value
 
-    # low income state
-    vla = vla_up
-    iter = 0
-    vla = vla_up
-    @label startl
-    vla = max(vla, eps())    
-    cl = vla^(-1 / γ)
-    μla = yl + r * a - cl
-    if (iter == 0) && (μla <= 0)
-        iter += 1
-        vla = vla_down
-        @goto startl
-    end
-    if (a ≈ amin) && (μla <= 0.0)
-        cl = yl + r * amin
-        μla = 0.0
-        vla = cl^(-γ)
+    # upwinding vl
+    vla_up = max(vla_up, eps())
+    cl_up = vla_up^(-1 / γ)
+    μla_up = yl + r * a - cl_up
+    if μla_up >= 0.0
+        vla = vla_up
+        cl = cl_up
+        μla = μla_up
+    else
+        vla_down = max(vla_down, eps())
+        cl_down = vla_down^(-1 / γ)
+        μla_down = yl + r * a - cl_down
+        if μla_down <= 0.0 && a > amin
+            vla = vla_down
+            cl = cl_down
+            μla = μla_down
+        else
+            # If the two candidates straddle zero OR drift is negative at minimum asset threshold  
+            # (i.e. borrowing constraint), then, we must have drift μla = 0.
+            cl = yl + r * a
+            μla = 0.0
+            vla = cl^(-γ)
+        end
     end
     vlt = - (cl^(1 - γ) / (1 - γ) + μla * vla + λlh * (vh - vl) - ρ * vl)
    
-    # high income state
-    vha = vha_up
-    iter = 0
-    vha = vha_up
-    @label starth
-    vha = max(vha, eps())    
-    ch = vha^(-1 / γ)
-    μha = yh + r * a - ch
-    if (iter == 0) && (μha <= 0)
-        iter += 1
-        vha = vha_down
-        @goto starth
-    end
-    if (a ≈ amin) && (μha <= 0.0)
-        ch = yh + r * amin
-        μha = 0.0
-        vha = ch^(-γ)
+    # upwinding vh
+    vha_up = max(vha_up, eps())
+    ch_up = vha_up^(-1 / γ)
+    μha_up = yh + r * a - ch_up
+    if μha_up >= 0.0
+        vha = vha_up
+        ch = ch_up
+        μha = μha_up
+    else
+        vha_down = max(vha_down, eps())
+        ch_down = vha_down^(-1 / γ)
+        μha_down = yh + r * a - ch_down
+        if μha_down <= 0.0 && a > amin
+            vha = vha_down
+            ch = ch_down
+            μha = μha_down
+        else
+            # If the two candidates straddle zero OR drift is negative at minimum asset threshold  
+            # (i.e. borrowing constraint), then, we must have drift μha = 0.
+            ch = yh + r * a
+            μha = 0.0
+            vha = ch^(-γ)
+        end
     end
     vht = - (ch^(1 - γ) / (1 - γ) + μha * vha + λhl * (vl - vh) - ρ * vh)
     
@@ -75,6 +87,5 @@ stategrid = OrderedDict(:a => m.amin .+ range(0, (m.amax - m.amin)^(1/2), length
 yend = OrderedDict(:vl => (m.ρ ./ m.γ .+ (1 .- 1 / m.γ) .* m.r)^(-m.γ) .* (stategrid[:a] .+ m.yl ./ m.r).^(1-m.γ) ./ (1 - m.γ), :vh => (m.ρ ./ m.γ .+ (1 .- m.γ) .* m.r)^(-m.γ)  .* (stategrid[:a] .+ m.yh ./ m.r).^(1-m.γ) ./ (1 - m.γ))
 result = pdesolve(m, stategrid, yend)
 @assert result.residual_norm <= 1e-5
-
 
 

--- a/examples/ConsumptionProblem/WangWangYang.jl
+++ b/examples/ConsumptionProblem/WangWangYang.jl
@@ -16,22 +16,31 @@ function (m::WangWangYangModel)(state::NamedTuple, y::NamedTuple)
     (; μ, σ, r, ρ, γ, ψ, wmin, wmax) = m
     (; w) = state
     (; p, pw_up, pw_down, pww) = y
-    pw = pw_up
-    iter = 0
-    @label start
-    pw = max(pw, sqrt(eps()))
-    c = (r + ψ * (ρ - r)) * p * pw^(-ψ)
-    μw = (r - μ + σ^2) * w + 1 - c
-    if (iter == 0) & (μw <= 0)
-        iter += 1
-        pw = pw_down
-        @goto start
-    end
-   #  One only needs a ghost node if μw <= 0 (since w^2p_ww = 0). In this case, we obtain a formula for pw so that c <= 1
-    if w ≈ wmin && μw <= 0.0
-        μw = 0.0
-        c = 1.0
-        pw = (c / ((r + ψ * (ρ - r))))^(-1 / ψ)
+    A = r + ψ * (ρ - r)
+
+    # Upwind on the physical wealth drift of the controlled state process.
+    pw_up = max(pw_up, sqrt(eps()))
+    c_up = A * p * pw_up^(-ψ)
+    μw_up = (r - μ + σ^2) * w + 1 - c_up
+    if μw_up >= 0
+        pw = pw_up
+        c = c_up
+        μw = μw_up
+    else
+        pw_down = max(pw_down, sqrt(eps()))
+        c_down = A * p * pw_down^(-ψ)
+        μw_down = (r - μ + σ^2) * w + 1 - c_down
+        if (μw_down <= 0) && (w > wmin)
+            pw = pw_down
+            c = c_down
+            μw = μw_down
+        else
+            # If the two candidates straddle zero OR drift is negative at minimum asset threshold  
+            # we impose drift μw = 0.
+            μw = 0.0
+            c = 1 + (r - μ + σ^2) * w
+            pw = (c / (A * p))^(-1 / ψ)
+        end
     end
     # At the top, I use the solution of the unconstrainted, i.e. pw = 1 (I could also do reflecting boundary but less elegant)
     pt = - ((((r + ψ * (ρ - r)) * pw^(1 - ψ) - ψ * ρ) / (ψ - 1) + μ - γ * σ^2 / 2) * p + ((r - μ + γ * σ^2) * w + 1) * pw + σ^2 * w^2 / 2  * (pww - γ * pw^2 / p))
@@ -57,22 +66,30 @@ function solve!(pts, m, ws, ps)
     for i in eachindex(ws)
         w = ws[i]
         p, pw_up, pw_down, pww = ps[i], pw_ups[i], pw_downs[i], pwws[i]
-        pw = pw_up
-        iter = 0
-        @label start
-        pw = max(pw, sqrt(eps()))
-        c = (r + ψ * (ρ - r)) * p * pw^(-ψ)
-        μw = (r - μ + σ^2) * w + 1 - c
-        if (iter == 0) && (μw <= 0)
-            iter += 1
-            pw = pw_down
-            @goto start
-        end
-        #  One only needs a ghost node if μw <= 0 (since w^2p_ww = 0). In this case, we obtain a formula for pw so that c <= 1
-        if w ≈ wmin && μw <= 0.0
-            μw = 0.0
-            c = 1.0
-            pw = (c / ((r + ψ * (ρ - r))))^(-1 / ψ)
+        A = r + ψ * (ρ - r)
+
+        pw_up = max(pw_up, sqrt(eps()))
+        c_up = A * p * pw_up^(-ψ)
+        μw_up = (r - μ + σ^2) * w + 1 - c_up
+        if μw_up >= 0
+            pw = pw_up
+            c = c_up
+            μw = μw_up
+        else
+            pw_down = max(pw_down, sqrt(eps()))
+            c_down = A * p * pw_down^(-ψ)
+            μw_down = (r - μ + σ^2) * w + 1 - c_down
+            if (μw_down <= 0) && (w > wmin)
+                pw = pw_down
+                c = c_down
+                μw = μw_down
+            else
+                # If the two candidates straddle zero OR drift is negative at minimum asset threshold  
+                # we impose drift μw = 0.
+                μw = 0.0
+                c = 1 + (r - μ + σ^2) * w
+                pw = (c / (A * p))^(-1 / ψ)
+            end
         end
         pts[i] = - ((((r + ψ * (ρ - r)) * pw^(1 - ψ) - ψ * ρ) / (ψ - 1) + μ - γ * σ^2 / 2) * p + ((r - μ + γ * σ^2) * w + 1) * pw + σ^2 * w^2 / 2  * (pww - γ * pw^2 / p))
     end

--- a/src/EconPDEs.jl
+++ b/src/EconPDEs.jl
@@ -1,12 +1,14 @@
 module EconPDEs
-using LinearAlgebra: Tridiagonal, norm, I
-using SparseArrays: sparse
-using NLsolve: OnceDifferentiable, nlsolve, mcpsolve
+using LinearAlgebra: Tridiagonal, norm, I, SingularException
+using SparseArrays: sparse, findnz, SparseMatrixCSC
+using NLsolve: OnceDifferentiable, mcpsolve
+using NonlinearSolve: AutoFiniteDiff, AutoForwardDiff, NewtonRaphson,
+    NonlinearFunction, NonlinearProblem, TrustRegion, solve
 using OrderedCollections: OrderedDict 
 using BlockArrays: blocklengths
 using BlockBandedMatrices: BandedBlockBandedMatrix, Ones, blockbandwidths, subblockbandwidths, blocksize
 using FiniteDiff: finite_difference_jacobian!, JacobianCache
-using Printf: @printf
+using Printf: @printf, @sprintf
 ##############################################################################
 ##
 ## Load files
@@ -15,6 +17,7 @@ using Printf: @printf
 
 include("finiteschemesolve.jl")
 include("utils.jl")
+include("monotonicity.jl")
 
 struct EconPDEResult{Z, R, O}
 	zero::Z 			# solution
@@ -50,8 +53,4 @@ export OrderedDict,
 finiteschemesolve,
 pdesolve
 end
-
-
-
-
 

--- a/src/finiteschemesolve.jl
+++ b/src/finiteschemesolve.jl
@@ -5,45 +5,91 @@
 ##############################################################################
 
 # Implicit time step
-function implicit_timestep(G!, ypost, Δ; is_algebraic = fill(false, size(ypost)...), iterations = 100, verbose = true, method = :newton, autodiff = :forward, maxdist = sqrt(eps()), J0 = nothing, y̲ = fill(-Inf, length(ypost)), ȳ = fill(Inf, length(ypost)), reformulation = :smooth, autoscale = true, kwargs...)
+function _nonlinear_autodiff(autodiff)
+    if autodiff == :forward
+        return AutoForwardDiff()
+    elseif autodiff == :finite
+        return AutoFiniteDiff()
+    elseif autodiff == :central
+        return AutoFiniteDiff(fdjtype = Val(:central))
+    else
+        return autodiff
+    end
+end
+
+function _nonlinear_algorithm(method, autodiff; concrete_jac = true)
+    ad = _nonlinear_autodiff(autodiff)
+    if method == :newton
+        return NewtonRaphson(; autodiff = ad, concrete_jac = concrete_jac)
+    elseif method == :trust_region
+        return TrustRegion(; autodiff = ad, concrete_jac = concrete_jac)
+    elseif method == :linearization
+        return NewtonRaphson(; autodiff = ad, concrete_jac = concrete_jac)
+    else
+        throw(ArgumentError("method must be :newton, :trust_region, or :linearization"))
+    end
+end
+
+_has_bounds(y̲, ȳ) = any(x -> x != -Inf, y̲) || any(x -> x != Inf, ȳ)
+
+function _nonlinear_solve(G!, y0; jac = nothing, jac_prototype = nothing, iterations = 100, verbose = true, method = :newton, autodiff = :forward, maxdist = sqrt(eps()), kwargs...)
+    G_solve! = (du, u, p) -> G!(du, u)
+    f = jac === nothing ?
+        NonlinearFunction{true}(G_solve!; jac_prototype = jac_prototype) :
+        NonlinearFunction{true}(G_solve!; jac = (J, u, p) -> jac(J, u), jac_prototype = jac_prototype)
+    problem = NonlinearProblem(f, y0)
+    algorithm = _nonlinear_algorithm(method, autodiff; concrete_jac = true)
+    result = try
+        solve(problem, algorithm; maxiters = iterations, abstol = maxdist, verbose = verbose, kwargs...)
+    catch err
+        err isa SingularException || rethrow()
+        return y0, Inf
+    end
+    return result.u, norm(result.resid) / length(result.resid)
+end
+
+function implicit_timestep(G!, ypost, Δ; is_algebraic = fill(false, size(ypost)...), iterations = 100, verbose = true, method = :newton, autodiff = :forward, maxdist = sqrt(eps()), J0 = nothing, y̲ = fill(-Inf, length(ypost)), ȳ = fill(Inf, length(ypost)), reformulation = :smooth, autoscale = true, monotonicity_check = nothing, kwargs...)
     #
     #if any(is_algebraic)
     # One option is 
     # G_helper!(ydot, y) = (G!(ydot, y) ; ydot .*= 1 .+ .!is_algebraic .* (Δ - 1) ; ydot .-= .!is_algebraic .* (ypost .- y))
     # however does not work if Δ is Inf
     G_helper!(ydot, y) = (G!(ydot, y) ; ydot .-= .!is_algebraic .* (ypost .- y) ./ Δ)
-    if J0 == nothing
+    if J0 === nothing
         if method == :linearization
             method = :newton
         end
-        result = nlsolve(G_helper!, ypost; iterations = iterations, show_trace = verbose, ftol = maxdist, method = method, autodiff = autodiff, autoscale = autoscale)
-        zero, residual_norm = result.zero, result.residual_norm
+        zero, residual_norm = _nonlinear_solve(G_helper!, ypost; iterations = iterations, verbose = verbose, method = method, autodiff = autodiff, maxdist = maxdist, kwargs...)
     else
         # remove forwarddiff path and use FiniteDiff everytime
         colorvec = matrix_colors(J0)
         J0_sparse = J0 isa Tridiagonal ? J0 : sparse(J0)
         bbbcache = JacobianCache(ypost, colorvec = colorvec, sparsity = J0_sparse)
-        j_helper! = (J, y) -> finite_difference_jacobian!(J, G_helper!, y, bbbcache)
-        if any(x -> x != -Inf, y̲) || any(x -> x != Inf, ȳ)
-            # using mcpsolve if lower/upper bounds are given
+        function j_helper!(J, y)
+            finite_difference_jacobian!(J, G_helper!, y, bbbcache)
+            _run_monotonicity_check!(monotonicity_check, J, y)
+            return J
+        end
+        if _has_bounds(y̲, ȳ)
+            # HJBVI bounds are mixed complementarity conditions, not box-constrained roots.
             result = mcpsolve(OnceDifferentiable(G_helper!, j_helper!, deepcopy(ypost), deepcopy(ypost), J0_sparse), y̲, ȳ, ypost; iterations = iterations, show_trace = verbose, ftol = maxdist, method = method, reformulation = reformulation)
             zero, residual_norm = result.zero, result.residual_norm
         elseif method == :linearization
             finite_difference_jacobian!(J0_sparse, G!, ypost, bbbcache)
+            _run_monotonicity_check!(monotonicity_check, J0_sparse, ypost)
             GV = deepcopy(ypost)
             G!(GV, ypost)
             zero = (I + Δ .* J0_sparse) \ (ypost .- Δ .* (GV .- J0_sparse * ypost))
             residual_norm = 0.0
         else
-            result = nlsolve(OnceDifferentiable(G_helper!, j_helper!, deepcopy(ypost), deepcopy(ypost), J0_sparse), ypost; iterations = iterations, show_trace = verbose, ftol = maxdist, method = method, autoscale = autoscale, kwargs...)
-            zero, residual_norm = result.zero, result.residual_norm
+            zero, residual_norm = _nonlinear_solve(G_helper!, ypost; jac = j_helper!, jac_prototype = J0_sparse, iterations = iterations, verbose = verbose, method = method, autodiff = autodiff, maxdist = maxdist, kwargs...)
         end
     end
     return zero, residual_norm
 end
 
 # Solve for steady state
-function finiteschemesolve(G!, y0; Δ = 1.0, is_algebraic = fill(false, size(y0)...), iterations = 100, inner_iterations = 10, verbose = true, inner_verbose = false, method = :newton, autodiff = :forward, maxdist = sqrt(eps()), innerdist = sqrt(eps()), scale = 10.0, J0 = nothing, minΔ = 1e-9, y̲ = fill(-Inf, length(y0)), ȳ = fill(Inf, length(y0)), reformulation = :smooth, maxΔ = Inf, autoscale = true, kwargs...)
+function finiteschemesolve(G!, y0; Δ = 1.0, is_algebraic = fill(false, size(y0)...), iterations = 100, inner_iterations = 10, verbose = true, inner_verbose = false, method = :newton, autodiff = :forward, maxdist = sqrt(eps()), innerdist = sqrt(eps()), scale = 10.0, J0 = nothing, minΔ = 1e-9, y̲ = fill(-Inf, length(y0)), ȳ = fill(Inf, length(y0)), reformulation = :smooth, maxΔ = Inf, autoscale = true, monotonicity_check = nothing, kwargs...)
     ypost = y0
     ydot = zero(y0)
     # check that does not return NAN or zero
@@ -55,7 +101,7 @@ function finiteschemesolve(G!, y0; Δ = 1.0, is_algebraic = fill(false, size(y0)
         return ypost, residual_norm
     end
     if Δ == Inf
-        ypost, residual_norm = implicit_timestep(G!, y0, Δ; is_algebraic = is_algebraic, verbose = verbose, iterations = iterations,  method = method, autodiff = autodiff, maxdist = maxdist, J0 = J0, y̲ = y̲, ȳ = ȳ)
+        ypost, residual_norm = implicit_timestep(G!, y0, Δ; is_algebraic = is_algebraic, verbose = verbose, iterations = iterations,  method = method, autodiff = autodiff, maxdist = maxdist, J0 = J0, y̲ = y̲, ȳ = ȳ, monotonicity_check = monotonicity_check, kwargs...)
     else
         coef = 1.0
         oldresidual_norm = residual_norm
@@ -66,9 +112,9 @@ function finiteschemesolve(G!, y0; Δ = 1.0, is_algebraic = fill(false, size(y0)
         end
         while (iter < iterations) && (Δ >= minΔ) && (residual_norm > maxdist)
             iter += 1
-            y, nlresidual_norm = implicit_timestep(G!, ypost, Δ; is_algebraic = is_algebraic, verbose = inner_verbose, iterations = inner_iterations, method = method, autodiff = autodiff, maxdist = innerdist, J0 = J0, y̲ = y̲, ȳ = ȳ, reformulation = reformulation, kwargs...)
+            y, nlresidual_norm = implicit_timestep(G!, ypost, Δ; is_algebraic = is_algebraic, verbose = inner_verbose, iterations = inner_iterations, method = method, autodiff = autodiff, maxdist = innerdist, J0 = J0, y̲ = y̲, ȳ = ȳ, reformulation = reformulation, monotonicity_check = monotonicity_check, kwargs...)
             G!(ydot, y)
-            if any(x -> x != -Inf, y̲) || any(x -> x != Inf, ȳ)
+            if _has_bounds(y̲, ȳ)
                 mask = y̲ .+ eps() .<= y .<= ȳ .- eps() # only unconstrained ydot is relevant for residual_norm calculation
                 residual_norm, oldresidual_norm = norm(ydot .* (mask))/sum(mask), residual_norm
             else

--- a/src/monotonicity.jl
+++ b/src/monotonicity.jl
@@ -1,0 +1,138 @@
+mutable struct MonotonicityChecker
+    stategrid
+    ynames::Vector{Symbol}
+    ysize::Tuple
+    tol::Float64
+    max_warnings::Int
+    warned::Set{Tuple{Int, Int}}
+    suppressed::Bool
+end
+
+function MonotonicityChecker(stategrid::StateGrid, @nospecialize(yend); tol = 1e-6, max_warnings = 5)
+    return MonotonicityChecker(
+        stategrid,
+        collect(keys(yend)),
+        tuple(size(stategrid)..., length(yend)),
+        tol,
+        max_warnings,
+        Set{Tuple{Int, Int}}(),
+        false,
+    )
+end
+
+_run_monotonicity_check!(::Nothing, J, y) = nothing
+_run_monotonicity_check!(checker::Function, J, y) = checker(J, y)
+_run_monotonicity_check!(checker::MonotonicityChecker, J, y) = _check_monotonicity!(checker, J)
+
+_sparse_for_check(J::SparseMatrixCSC) = J
+_sparse_for_check(J) = sparse(J)
+
+function _check_monotonicity!(checker::MonotonicityChecker, J)
+    checker.max_warnings <= 0 && return nothing
+    (checker.suppressed && length(checker.warned) >= checker.max_warnings) && return nothing
+
+    cart = CartesianIndices(checker.ysize)
+    size(J, 1) == length(cart) || return nothing
+    size(J, 2) == length(cart) || return nothing
+
+    rows, cols, vals = findnz(_sparse_for_check(J))
+    for k in eachindex(vals)
+        val = vals[k]
+        val > checker.tol || continue
+
+        row = rows[k]
+        col = cols[k]
+        row == col && continue
+        (row, col) in checker.warned && continue
+
+        rowI = cart[row]
+        colI = cart[col]
+        _is_spatial_neighbor(checker, rowI, colI) || continue
+
+        if length(checker.warned) >= checker.max_warnings
+            _warn_suppressed!(checker)
+            return nothing
+        end
+
+        push!(checker.warned, (row, col))
+        _warn_nonmonotone(checker, rowI, colI, val)
+    end
+    return nothing
+end
+
+function _is_spatial_neighbor(checker::MonotonicityChecker, rowI::CartesianIndex, colI::CartesianIndex)
+    nstate = ndims(checker.stategrid)
+    rowI[nstate + 1] == colI[nstate + 1] || return false
+
+    changed = false
+    for d in 1:nstate
+        delta = colI[d] - rowI[d]
+        abs(delta) <= 1 || return false
+        changed |= delta != 0
+    end
+    return changed
+end
+
+function _warn_nonmonotone(checker::MonotonicityChecker, rowI::CartesianIndex, colI::CartesianIndex, residual_weight)
+    varname = checker.ynames[rowI[ndims(checker.stategrid) + 1]]
+    @warn "Non-monotone finite-difference stencil detected: positive residual off-diagonal implies a negative generator weight" variable=varname state=_format_state(checker, rowI) neighbor=_format_neighbor(checker, rowI, colI) residual_jacobian=residual_weight generator_weight=-residual_weight stencil_hint=_format_stencil_hint(checker, rowI, colI, varname)
+    return nothing
+end
+
+function _warn_suppressed!(checker::MonotonicityChecker)
+    checker.suppressed && return nothing
+    checker.suppressed = true
+    @warn "Further monotonicity warnings suppressed" limit=checker.max_warnings
+    return nothing
+end
+
+function _format_state(checker::MonotonicityChecker, I::CartesianIndex)
+    names = keys(checker.stategrid.x)
+    parts = Vector{String}(undef, ndims(checker.stategrid))
+    for d in 1:ndims(checker.stategrid)
+        parts[d] = string(names[d], "=", _format_number(checker.stategrid.x[d][I[d]]))
+    end
+    return join(parts, ", ")
+end
+
+function _format_neighbor(checker::MonotonicityChecker, rowI::CartesianIndex, colI::CartesianIndex)
+    names = keys(checker.stategrid.x)
+    parts = String[]
+    for d in 1:ndims(checker.stategrid)
+        delta = colI[d] - rowI[d]
+        if delta > 0
+            push!(parts, string(names[d], "+"))
+        elseif delta < 0
+            push!(parts, string(names[d], "-"))
+        end
+    end
+    return join(parts, ", ")
+end
+
+function _format_stencil_hint(checker::MonotonicityChecker, rowI::CartesianIndex, colI::CartesianIndex, varname::Symbol)
+    names = keys(checker.stategrid.x)
+    changed = Int[]
+    deltas = Int[]
+    for d in 1:ndims(checker.stategrid)
+        delta = colI[d] - rowI[d]
+        if delta != 0
+            push!(changed, d)
+            push!(deltas, delta)
+        end
+    end
+
+    if length(changed) == 1
+        d = changed[1]
+        suffix = deltas[1] > 0 ? "_up" : "_down"
+        return Symbol(varname, names[d], suffix)
+    elseif length(changed) == 2
+        d1, d2 = changed
+        suffix = sign(deltas[1]) == sign(deltas[2]) ? "_up" : "_down"
+        return Symbol(varname, names[d1], names[d2], suffix)
+    else
+        return Symbol(varname, "_neighbor")
+    end
+end
+
+_format_number(x::Real) = @sprintf("%.6g", x)
+_format_number(x) = sprint(show, x)

--- a/src/pdesolve.jl
+++ b/src/pdesolve.jl
@@ -1,5 +1,5 @@
 """
-    pdesolve(f, grid, yend [, τs]; is_algebraic = OrderedDict(k => false for k in keys(yend)), bc = nothing)
+    pdesolve(f, grid, yend [, τs]; is_algebraic = OrderedDict(k => false for k in keys(yend)), bc = nothing, check_monotonicity = false)
     
     solves a system of pdes with an arbitrary number of functions and up to state variable. Denote  F the number of functions to solve for and S the number of state variables.
 
@@ -12,8 +12,13 @@
     * grid is an OrderedDict that, for each state, associates an AbstractVector (for the grid)
     * yend is an OrderedDict that gives the terminal value of each function in the system of PDEs
     * τs (optional) is a time grid on which to solve the pde on. In this case, yend corresponds to the solution at time τs[end]
+
+    ### Keyword arguments
+    * check_monotonicity: if true, warn when the assembled residual Jacobian has same-variable spatial off-diagonal entries with the wrong monotonicity sign. Defaults to false.
+    * monotonicity_tol: tolerance for the monotonicity check. Defaults to 1e-6.
+    * monotonicity_max_warnings: maximum number of monotonicity warnings to print. Defaults to 5.
 """
-function pdesolve(apm, @nospecialize(grid), @nospecialize(yend), τs::Union{Nothing, AbstractVector} = nothing; is_algebraic = OrderedDict(k => false for k in keys(yend)), bc = nothing, verbose = true, kwargs...)
+function pdesolve(apm, @nospecialize(grid), @nospecialize(yend), τs::Union{Nothing, AbstractVector} = nothing; is_algebraic = OrderedDict(k => false for k in keys(yend)), bc = nothing, verbose = true, check_monotonicity = false, monotonicity_tol = 1e-6, monotonicity_max_warnings = 5, kwargs...)
     stategrid = StateGrid(NamedTuple(grid))
     S = size(stategrid)
     all(size(v) == S for v in values(yend)) || throw(ArgumentError("The length of initial guess (e.g. terminal value) does not equal the length of the state space"))
@@ -32,6 +37,7 @@ function pdesolve(apm, @nospecialize(grid), @nospecialize(yend), τs::Union{Noth
 
     # create sparsity
     J0 = sparse_jacobian(stategrid, yend)
+    monotonicity_check = check_monotonicity ? MonotonicityChecker(stategrid, yend; tol = monotonicity_tol, max_warnings = monotonicity_max_warnings) : nothing
     Tsolution = Type{tuple(keys(yend)...)}
 
     # iterate on time
@@ -53,7 +59,7 @@ function pdesolve(apm, @nospecialize(grid), @nospecialize(yend), τs::Union{Noth
                 as[iτ] = merge(ys[iτ], as[iτ])
             end
             if iτ > 1
-                y_M, residual_norms[iτ] = implicit_timestep((ydot, y) -> hjb!(apm_onestep, stategrid, Tsolution, ydot, y, bc_M, size(yend_M)), vec(y_M), τs[iτ] - τs[iτ-1]; is_algebraic = vec(is_algebraic_M), verbose = false, J0 = J0, kwargs...)
+                y_M, residual_norms[iτ] = implicit_timestep((ydot, y) -> hjb!(apm_onestep, stategrid, Tsolution, ydot, y, bc_M, size(yend_M)), vec(y_M), τs[iτ] - τs[iτ-1]; is_algebraic = vec(is_algebraic_M), verbose = false, J0 = J0, monotonicity_check = monotonicity_check, kwargs...)
                 if verbose
                     @printf "%8g   %8.4e\n" τs[iτ-1] residual_norms[iτ]
                 end
@@ -63,7 +69,7 @@ function pdesolve(apm, @nospecialize(grid), @nospecialize(yend), τs::Union{Noth
         return EconPDEResult(ys, residual_norms, as)
     else
         a = get_a(apm, stategrid, Tsolution, yend_M, bc_M)
-        y_M, residual_norm = finiteschemesolve((ydot, y) -> hjb!(apm, stategrid, Tsolution, ydot, y, bc_M, size(yend_M)), vec(yend_M); is_algebraic = vec(is_algebraic_M),  J0 = J0, verbose = verbose, kwargs... )
+        y_M, residual_norm = finiteschemesolve((ydot, y) -> hjb!(apm, stategrid, Tsolution, ydot, y, bc_M, size(yend_M)), vec(yend_M); is_algebraic = vec(is_algebraic_M),  J0 = J0, verbose = verbose, monotonicity_check = monotonicity_check, kwargs... )
         y_M = reshape(y_M, size(yend_M)...)
         _setindex!(y, y_M)
         if a !== nothing
@@ -183,5 +189,3 @@ function _setindex!(@nospecialize(a), apm, stategrid::StateGrid, Tsolution, y_M:
           $(Expr(:block, [Expr(:call, :setindex!, :ydot_M, Expr(:call, :getproperty, :outi, Meta.quot(Symbol(Tsolution.parameters[1][k], :t))), :i, k) for k in 1:N]...))
      end
  end
-
-

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,30 @@
 using Test
+using Logging
+using EconPDEs
+
+@testset "Monotonicity diagnostics" begin
+    grid = OrderedDict(:x => range(0.0, 1.0, length = 2))
+    y0 = OrderedDict(:V => collect(range(1.0, 2.0, length = 2)))
+
+    function wrong_upwind(state, y)
+        (; V, Vx_down) = y
+        Vt = -(1.0 + V + Vx_down)
+        return (; Vt)
+    end
+
+    @test_logs (:warn, r"Non-monotone finite-difference stencil") pdesolve(wrong_upwind, grid, y0; Δ = Inf, iterations = 1, verbose = false, check_monotonicity = true)
+
+    grid_good = OrderedDict(:x => range(0.0, 1.0, length = 3))
+    y_good = OrderedDict(:V => collect(range(1.0, 2.0, length = 3)))
+
+    function correct_upwind(state, y)
+        (; V, Vx_up) = y
+        Vt = -(1.0 + V + Vx_up)
+        return (; Vt)
+    end
+
+    @test_logs min_level=Logging.Warn pdesolve(correct_upwind, grid_good, y_good; Δ = Inf, iterations = 1, verbose = false, check_monotonicity = true)
+end
 
 for x in (:CampbellCochrane, :Wachter, :BansalYaron, :GarleanuPanageas, :DiTella, :Haddad, :TuckmanVila, :HeKrishnamurthy, :BrunnermeirSannikov)
 	@testset "$x" begin include("../examples/AssetPricing/$(x).jl") end


### PR DESCRIPTION
Switch ordinary nonlinear PDE solves from `NLsolve` to `NonlinearSolve.jl`, which is faster on the benchmark examples, while keeping `NLsolve` for `mcpsolve` in bounded HJBVI/optimal-stopping problems.

Add opt-in monotonicity diagnostics to `pdesolve` through `check_monotonicity`, `monotonicity_tol`, and `monotonicity_max_warnings`; the check inspects assembled residual-Jacobian neighbor signs and is documented as diagnostic for transformed/endogenous-control equations. Bump the package version to `1.5.0`.