### PR TITLE
Reorganize example gallery and standardize page structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,11 +240,13 @@ This checks the effective neighbor weights in the fully assembled equation, afte
 
 ## Examples
 
-The **[documentation](https://matthieugomez.github.io/EconPDEs.jl/dev)** works through a gallery of models — each one solves the model, plots the solution, and explains it economically. Together they exercise the full range of what `pdesolve` handles: one to several state variables, single and coupled value functions, stationary and time-dependent HJBs, and reflecting, state-constraint, degenerate, and free (optimal-stopping) boundaries. The runnable source scripts live in [`examples/macro`](examples/macro) and [`examples/finance`](examples/finance).
+The **[documentation](https://matthieugomez.github.io/EconPDEs.jl/dev)** works through a gallery of models — each one solves the model, plots the solution, and explains it economically. Together they exercise the full range of what `pdesolve` handles: one to several state variables, single and coupled value functions, stationary and time-dependent HJBs, and reflecting, state-constraint, degenerate, and free (optimal-stopping) boundaries. The runnable source scripts live under [`examples/`](examples), starting with the [neoclassical growth model](examples/neoclassical_growth.jl) and grouped into `consumption_saving`, `asset_pricing`, and `corporate_finance`.
 
-**Macro** — deterministic neoclassical (Ramsey) growth, and consumption–saving with a borrowing constraint: Achdou–Han–Lasry–Lions–Moll (one-asset, two-asset, and two-income-state variants) and Wang–Wang–Yang (2016).
+**Consumption–saving** — with a borrowing constraint: Achdou–Han–Lasry–Lions–Moll (one-asset, two-income-state, and two-asset variants) and Wang–Wang–Yang (2016).
 
-**Finance** — habit (Campbell–Cochrane 1999), long-run risk (Bansal–Yaron 2004), disaster risk (Wachter 2013), finite-horizon arbitrage (Tuckman–Vila 1992), heterogeneous-agent and intermediary asset pricing (He–Krishnamurthy 2013, Brunnermeier–Sannikov 2013, Gârleanu–Panageas 2015, Di Tella 2017, Haddad, Gomez), optimal default (Leland 1994), and investment with a financing constraint (Bolton–Chen–Wang 2009).
+**Asset pricing** — habit (Campbell–Cochrane 1999), long-run risk (Bansal–Yaron 2004), endogenous volatility (Haddad), disaster risk (Wachter 2013), finite-horizon arbitrage (Tuckman–Vila 1992), and heterogeneous-agent / intermediary asset pricing (Gârleanu–Panageas 2015, He–Krishnamurthy 2013, Brunnermeier–Sannikov 2013, Di Tella 2017, Gomez).
+
+**Corporate finance** — optimal default (Leland 1994) and investment with a financing constraint (Bolton–Chen–Wang 2009).
 
 ## Numerical Details
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,43 +1,50 @@
 using Documenter
 using Literate
 using EconPDEs
+import Plots
 
-# Render GR plots without a display (needed on CI).
+# Render GR plots without a display (needed on CI), and give every figure enough margin that
+# the axis labels are never clipped.
 ENV["GKSwstype"] = "100"
+Plots.default(; left_margin = 5Plots.mm, bottom_margin = 5Plots.mm)
 
 const EXAMPLES_DIR = joinpath(dirname(@__DIR__), "examples")
 const GENERATED_DIR = joinpath(@__DIR__, "src", "examples")
 
-# Each example is a Literate script under examples/macro or examples/finance. Rendering it
-# here (and running its code) is what verifies the example — they are not in the test suite.
+# Each example is a Literate script under examples/. Rendering it here (and running its code) is
+# what verifies the example — they are not in the test suite.
 isdir(GENERATED_DIR) && rm(GENERATED_DIR; recursive = true)
 
-macro_examples = [
-    "Neoclassical growth"                   => "macro/neoclassical_growth.jl",
-    "Consumption–saving: two income states" => "macro/consumption_saving_two_income_states.jl",
-    "Consumption–saving: one asset"         => "macro/consumption_saving_one_asset.jl",
-    "Consumption–saving: two assets"        => "macro/consumption_saving_two_assets.jl",
-    "Wang–Wang–Yang: liquidity management"  => "macro/wang_wang_yang.jl",
+consumption_saving = [
+    "Consumption–saving: one asset"         => "consumption_saving/consumption_saving_one_asset.jl",
+    "Consumption–saving: two income states" => "consumption_saving/consumption_saving_two_income_states.jl",
+    "Consumption–saving: two assets"        => "consumption_saving/consumption_saving_two_assets.jl",
+    "Wang–Wang–Yang: liquidity management"  => "consumption_saving/wang_wang_yang.jl",
 ]
-finance_examples = [
-    "Leland: optimal default"                 => "finance/leland.jl",
-    "Bolton–Chen–Wang: financing constraint"  => "finance/bolton_chen_wang.jl",
-    "Campbell–Cochrane: habit"                => "finance/campbell_cochrane.jl",
-    "Wachter: rare disasters"                 => "finance/wachter.jl",
-    "Haddad: endogenous volatility"           => "finance/haddad.jl",
-    "Bansal–Yaron: long-run risk (2D)"        => "finance/bansal_yaron.jl",
-    "Tuckman–Vila: finite horizon"            => "finance/tuckman_vila.jl",
-    "Gârleanu–Panageas: heterogeneous agents" => "finance/garleanu_panageas.jl",
-    "He–Krishnamurthy: intermediaries"        => "finance/he_krishnamurthy.jl",
-    "Di Tella: balance-sheet risk (2D)"       => "finance/di_tella.jl",
-    "Brunnermeier–Sannikov: macro-finance"    => "finance/brunnermeier_sannikov.jl",
-    "Gomez: wealth distribution"              => "finance/gomez.jl",
+asset_pricing = [
+    "Campbell–Cochrane: habit"                => "asset_pricing/campbell_cochrane.jl",
+    "Bansal–Yaron: long-run risk (2D)"        => "asset_pricing/bansal_yaron.jl",
+    "Haddad: endogenous volatility"           => "asset_pricing/haddad.jl",
+    "Wachter: rare disasters"                 => "asset_pricing/wachter.jl",
+    "Tuckman–Vila: finite horizon"            => "asset_pricing/tuckman_vila.jl",
+    "Gârleanu–Panageas: heterogeneous agents" => "asset_pricing/garleanu_panageas.jl",
+    "He–Krishnamurthy: intermediaries"        => "asset_pricing/he_krishnamurthy.jl",
+    "Brunnermeier–Sannikov: macro-finance"    => "asset_pricing/brunnermeier_sannikov.jl",
+    "Di Tella: balance-sheet risk (2D)"       => "asset_pricing/di_tella.jl",
+    "Gomez: wealth distribution"              => "asset_pricing/gomez.jl",
+]
+corporate_finance = [
+    "Leland: optimal default"                => "corporate_finance/leland.jl",
+    "Bolton–Chen–Wang: financing constraint" => "corporate_finance/bolton_chen_wang.jl",
 ]
 
 function literate_page((title, relpath))
     Literate.markdown(joinpath(EXAMPLES_DIR, relpath), joinpath(GENERATED_DIR, dirname(relpath)); documenter = true)
     return title => joinpath("examples", replace(relpath, r"\.jl$" => ".md"))
 end
+
+# Neoclassical growth is the standalone entry-point example (rendered directly under examples/).
+Literate.markdown(joinpath(EXAMPLES_DIR, "neoclassical_growth.jl"), GENERATED_DIR; documenter = true)
 
 makedocs(;
     sitename = "EconPDEs.jl",
@@ -48,8 +55,10 @@ makedocs(;
     pages = [
         "Home" => "index.md",
         "Examples" => [
-            "Macro"   => literate_page.(macro_examples),
-            "Finance" => literate_page.(finance_examples),
+            "Neoclassical growth" => "examples/neoclassical_growth.md",
+            "Consumption–saving"  => literate_page.(consumption_saving),
+            "Asset pricing"       => literate_page.(asset_pricing),
+            "Corporate finance"   => literate_page.(corporate_finance),
         ],
         "API reference" => "api.md",
     ],

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -19,4 +19,4 @@ reference lists every solver option.
 
 The **Examples** in the sidebar each solve a model, plot the solution, and explain what it
 means economically. They are grouped into macro and finance models and ordered roughly from the simplest to the
-most involved — start with [Neoclassical growth](examples/macro/neoclassical_growth.md).
+most involved — start with [Neoclassical growth](examples/neoclassical_growth.md).

--- a/examples/asset_pricing/bansal_yaron.jl
+++ b/examples/asset_pricing/bansal_yaron.jl
@@ -14,20 +14,47 @@
 # and ``\sigma_v^2 p_v^2/p`` come from the market prices of long-run-risk and variance risk.
 
 # ## The model
+#
+# The parameters live in a `struct`:
 
 using EconPDEs, Distributions, Plots
 
 Base.@kwdef struct BansalYaronModel
-    μbar::Float64 = 0.018
-    vbar::Float64 = 0.00073
-    κμ::Float64 = 0.252
-    νμ::Float64 = 0.528
-    κv::Float64 = 0.156
-    νv::Float64 = 0.00354
-    ρ::Float64 = 0.024
-    γ::Float64 = 7.5
-    ψ::Float64 = 1.5
+    μbar::Float64 = 0.018    # long-run mean of expected consumption growth
+    vbar::Float64 = 0.00073  # long-run mean of consumption variance
+    κμ::Float64 = 0.252      # mean-reversion speed of expected growth
+    νμ::Float64 = 0.528      # volatility of expected growth
+    κv::Float64 = 0.156      # mean-reversion speed of variance
+    νv::Float64 = 0.00354    # volatility of variance (vol of vol)
+    ρ::Float64 = 0.024       # discount rate
+    γ::Float64 = 7.5         # relative risk aversion
+    ψ::Float64 = 1.5         # elasticity of intertemporal substitution
 end
+
+# ## The state space
+#
+# We build the grid and the initial guess first, because they fix the names used everywhere
+# else. This model has two state variables, so the grid is a `NamedTuple` with two keys (`μ` and
+# `v`); the guess is a `NamedTuple` whose key is the unknown function (`p`, the wealth–consumption
+# ratio), a matrix over the ``(\mu, v)`` grid. These names reappear inside the equation below —
+# e.g. `pμ_up` is the forward finite difference of `p` in `μ`, and `pμv` is the cross-partial. The
+# grid spans the ergodic ranges of ``\mu`` (Normal) and ``v`` (Gamma). The ``\sqrt v`` diffusion
+# vanishes at ``v = 0``, a degenerate boundary where no condition is imposed.
+
+m = BansalYaronModel()
+μn, vn = 30, 30
+μdistribution = Normal(m.μbar, sqrt(m.νμ^2 * m.vbar / (2 * m.κμ)))
+μs = range(quantile(μdistribution, 0.01), quantile(μdistribution, 0.99), length = μn)
+νdistribution = Gamma(2 * m.κv * m.vbar / m.νv^2, m.νv^2 / (2 * m.κv))
+vs = range(quantile(νdistribution, 0.0), quantile(νdistribution, 0.99), length = vn)
+stategrid = (; μ = μs, v = vs)
+yend = (; p = ones(μn, vn))
+
+# ## The equation
+#
+# We now write the function encoding the HJB equation. Following the package convention, it
+# takes the current `state` (a grid point) and `u` (each unknown together with its
+# finite-difference derivatives there) and returns the time derivative of each unknown.
 
 function (m::BansalYaronModel)(state::NamedTuple, u::NamedTuple)
     (; μbar, vbar, κμ, νμ, κv, νv, ρ, γ, ψ) = m
@@ -61,19 +88,8 @@ function (m::BansalYaronModel)(state::NamedTuple, u::NamedTuple)
     return (; pt)
 end
 
-# ## Solving it
-#
-# The grid spans the ergodic ranges of ``\mu`` (Normal) and ``v`` (Gamma). The ``\sqrt v``
-# diffusion vanishes at ``v = 0``, a degenerate boundary where no condition is imposed.
+# With the equation, grid, and guess in hand, `pdesolve` solves the stationary system:
 
-m = BansalYaronModel()
-μn, vn = 30, 30
-μdistribution = Normal(m.μbar, sqrt(m.νμ^2 * m.vbar / (2 * m.κμ)))
-μs = range(quantile(μdistribution, 0.01), quantile(μdistribution, 0.99), length = μn)
-νdistribution = Gamma(2 * m.κv * m.vbar / m.νv^2, m.νv^2 / (2 * m.κv))
-vs = range(quantile(νdistribution, 0.0), quantile(νdistribution, 0.99), length = vn)
-stategrid = (; μ = μs, v = vs)
-yend = (; p = ones(μn, vn))
 result = pdesolve(m, stategrid, yend)
 
 # ## The solution

--- a/examples/asset_pricing/brunnermeier_sannikov.jl
+++ b/examples/asset_pricing/brunnermeier_sannikov.jl
@@ -9,25 +9,55 @@
 # difference. That order-dependent sweep is why the model struct is mutable and carries `q_old`.
 
 # ## The model
+#
+# The parameters:
 
 using EconPDEs, Roots, Plots
 
 Base.@kwdef mutable struct BrunnermeierSannikov
   ## Calibration uses Section 3.6 of the textbook chapter (I think r is typo for ρH)
-  ρE::Float64 = 0.06
-  ρH::Float64 = 0.05
-  γ::Float64 = 2.0
-  ψ::Float64 = 0.5
-  δ::Float64 = 0.05
-  σ::Float64 = 0.1
-  κ::Float64 = 10.0
-  a::Float64 = 0.11
-  alow::Float64 = 0.03
-  χlow::Float64 = 0.5
-  q_old::Float64 = 1.0
-  qx_old::Float64 = 0.0
-  Ψ_old::Float64 = 1.0
+  ρE::Float64 = 0.06      # experts' rate of time preference (discount rate)
+  ρH::Float64 = 0.05      # households' rate of time preference (discount rate)
+  γ::Float64 = 2.0        # relative risk aversion
+  ψ::Float64 = 0.5        # elasticity of intertemporal substitution
+  δ::Float64 = 0.05       # depreciation rate of capital
+  σ::Float64 = 0.1        # exogenous (fundamental) volatility of capital
+  κ::Float64 = 10.0       # investment adjustment-cost parameter
+  a::Float64 = 0.11       # experts' productivity (output per unit capital)
+  alow::Float64 = 0.03    # households' productivity (output per unit capital)
+  χlow::Float64 = 0.5     # minimum equity retention (skin-in-the-game floor)
+  q_old::Float64 = 1.0    # previous capital price q (carried across the sweep)
+  qx_old::Float64 = 0.0   # previous q_x (carried across the sweep)
+  Ψ_old::Float64 = 1.0    # previous experts' capital share Ψ (carried across the sweep)
 end
+
+# ## The state space
+#
+# We build the grid and the initial guess first, because they fix the names used everywhere else.
+# The grid is a `NamedTuple` whose key is the state variable (`x`, the experts' wealth share); the
+# guess is a `NamedTuple` whose keys are the unknown functions (`pE, pH`), holding one starting
+# value at each grid point. These names are what reappear inside the equation below — e.g.
+# `pEx_up` will be the forward finite difference of `pE` in `x`.
+#
+# One state ``x \in (0, 1)`` on 200 interior grid points. Because the sweep marches from the lower
+# boundary upward, the grid spacing `Δx` and its minimum `xmin` are computed here and later passed
+# into the model.
+
+m = BrunnermeierSannikov()
+xn = 200
+stategrid =  (; x = range(0, 1.0, length = xn+2)[2:(end-1)])
+Δx = step(stategrid[:x])
+xmin = minimum(stategrid[:x])
+yend = (; pE =  9 .* ones(xn), pH =   10 .* ones(xn))
+
+# ## The equation
+#
+# We now write the function encoding the equilibrium conditions. Following the package convention,
+# it takes the current `state` (a grid point) and `u` — the local bundle holding each unknown and
+# its finite-difference derivatives there — plus the grid spacing `Δx` and lower bound `xmin`, and
+# returns the time derivative of each unknown (`pEt, pHt`). Inside, a root-find recovers the
+# capital price ``q`` and the experts' capital share ``\Psi``, distinguishing the crisis region
+# (``\Psi < 1``) from the normal region (``\Psi = 1``).
 
 function (m::BrunnermeierSannikov)(state::NamedTuple, u::NamedTuple, Δx, xmin)
   (; ρE, ρH, γ, ψ, δ, σ, κ, a, alow, χlow) = m
@@ -125,18 +155,10 @@ function (m::BrunnermeierSannikov)(state::NamedTuple, u::NamedTuple, Δx, xmin)
   (; pEt, pHt), (; x, r, μx, σx, Ψ, κ, κE, κH, σE, σH, σq, pEt, pHt, q, qx, qxx, μq, μx2, Φ, χ, d, μR, pExx, pHxx)
 end
 
-# ## Solving it
-#
-# One state ``x \in (0, 1)``, the experts' wealth share, on 200 interior grid points. The sweep is
-# order-dependent — it marches from the lower boundary `xmin` upward — so the grid spacing `Δx`
-# and `xmin` are passed into the model and finite-difference autodiff is used.
+# The sweep is order-dependent — it marches from the lower boundary `xmin` upward, each step
+# reusing the previous ``q`` carried in the mutable model — so `Δx` and `xmin` are passed into the
+# model and finite-difference autodiff is used:
 
-m = BrunnermeierSannikov()
-xn = 200
-stategrid =  (; x = range(0, 1.0, length = xn+2)[2:(end-1)])
-Δx = step(stategrid[:x])
-xmin = minimum(stategrid[:x])
-yend = (; pE =  9 .* ones(xn), pH =   10 .* ones(xn))
 @time result = pdesolve((state, u) -> m(state, u, Δx, xmin), stategrid, yend; autodiff = :finite)
 
 # ## The solution

--- a/examples/asset_pricing/campbell_cochrane.jl
+++ b/examples/asset_pricing/campbell_cochrane.jl
@@ -13,17 +13,49 @@
 # rate ``r`` are all functions of ``s`` through the habit.
 
 # ## The model
+#
+# The parameters live in a `struct`:
 
 using EconPDEs, Plots
 
 Base.@kwdef struct CampbellCochraneModel
-    μ::Float64 = 0.0189
-    σ::Float64 = 0.015
-    γ::Float64 = 2.0
-    ρ::Float64 = 0.116
-    κs::Float64 = 0.138
-    b::Float64 = 0.0
+    μ::Float64 = 0.0189    # mean consumption growth
+    σ::Float64 = 0.015     # volatility of consumption growth
+    γ::Float64 = 2.0       # utility curvature (relative risk aversion)
+    ρ::Float64 = 0.116     # discount rate
+    κs::Float64 = 0.138    # mean-reversion speed of log surplus consumption ratio
+    b::Float64 = 0.0       # sensitivity of riskless rate to surplus ratio (b=0 ⇒ constant r)
 end
+
+# ## The state space
+#
+# We build the grid and the initial guess first, because they fix the names used everywhere
+# else. The grid is a `NamedTuple` whose key is the state variable (`s`, the log surplus
+# consumption ratio); the guess is a `NamedTuple` whose key is the unknown function (`p`, the
+# price–consumption ratio). These names reappear inside the equation below — e.g. `ps_up` will
+# be the forward finite difference of `p` in `s`. The grid concentrates points near the
+# reflecting upper bound ``s_{\max}``, where the surplus ratio is highest, and stretches far
+# into the left tail.
+
+function initialize_stategrid(m::CampbellCochraneModel; sn = 1000)
+    (; μ, σ, γ, ρ, κs, b) = m
+    Sbar = σ * sqrt(γ / (κs - b / γ))
+    sbar = log(Sbar)
+    smax = sbar + 0.5 * (1 - Sbar^2)
+    shigh = log.(range(0.0, exp(smax), length = div(sn, 10)))
+    slow = range(-300.0, shigh[2], length = sn - div(sn, 10))
+    (; s = vcat(slow[1:(end-1)], shigh[2:end]))
+end
+
+m = CampbellCochraneModel()
+stategrid = initialize_stategrid(m)
+yend = (; p = ones(length(stategrid[:s])))
+
+# ## The equation
+#
+# We now write the function encoding the HJB equation. Following the package convention, it
+# takes the current `state` (a grid point) and `u` (each unknown together with its
+# finite-difference derivatives there) and returns the time derivative of each unknown.
 
 function (m::CampbellCochraneModel)(state::NamedTuple, u::NamedTuple)
     (; μ, σ, γ, ρ, κs, b) = m
@@ -45,24 +77,8 @@ function (m::CampbellCochraneModel)(state::NamedTuple, u::NamedTuple)
     return (; pt)
 end
 
-# ## Solving it
-#
-# The grid concentrates points near the reflecting upper bound ``s_{\max}``, where the surplus
-# ratio is highest, and stretches far into the left tail.
+# With the equation, grid, and guess in hand, `pdesolve` solves the stationary system:
 
-function initialize_stategrid(m::CampbellCochraneModel; sn = 1000)
-    (; μ, σ, γ, ρ, κs, b) = m
-    Sbar = σ * sqrt(γ / (κs - b / γ))
-    sbar = log(Sbar)
-    smax = sbar + 0.5 * (1 - Sbar^2)
-    shigh = log.(range(0.0, exp(smax), length = div(sn, 10)))
-    slow = range(-300.0, shigh[2], length = sn - div(sn, 10))
-    (; s = vcat(slow[1:(end-1)], shigh[2:end]))
-end
-
-m = CampbellCochraneModel()
-stategrid = initialize_stategrid(m)
-yend = (; p = ones(length(stategrid[:s])))
 result = pdesolve(m, stategrid, yend)
 
 # ## The solution

--- a/examples/asset_pricing/di_tella.jl
+++ b/examples/asset_pricing/di_tella.jl
@@ -8,28 +8,42 @@
 # market-clearing constraint (`is_algebraic`) rather than by its own time derivative.
 
 # ## The model
+#
+# The parameters:
 
 using EconPDEs, Distributions, Plots
 
 Base.@kwdef mutable struct DiTellaModel
   ## Utility Function
-  γ::Float64 = 5.0
-  ψ::Float64 = 1.5
-  ρ::Float64 = 0.05
-  τ::Float64 = 0.4
+  γ::Float64 = 5.0        # relative risk aversion
+  ψ::Float64 = 1.5        # elasticity of intertemporal substitution
+  ρ::Float64 = 0.05       # rate of time preference (discount rate)
+  τ::Float64 = 0.4        # transition rate between experts and households
 
   ## Technology
-  A::Float64 = 200.0
-  σ::Float64 = 0.03
+  A::Float64 = 200.0      # investment adjustment-cost (technology) parameter
+  σ::Float64 = 0.03       # aggregate (fundamental) volatility of capital
 
   ## MoralHazard
-  ϕ::Float64 = 0.2
+  ϕ::Float64 = 0.2        # moral-hazard idiosyncratic-risk retention parameter
 
   ## Idiosyncratic
-  νbar::Float64 = 0.24
-  κν::Float64 = 0.22
-  σνbar::Float64 = -0.13
+  νbar::Float64 = 0.24    # long-run mean of idiosyncratic variance ν
+  κν::Float64 = 0.22      # mean-reversion speed of ν (uncertainty process)
+  σνbar::Float64 = -0.13  # volatility loading of the ν process
 end
+
+# ## The state space
+#
+# We build the grid and the initial guess first, because they fix the names used everywhere else.
+# The grid is a `NamedTuple` whose keys are the two state variables (`x`, the experts' wealth
+# share, and `ν`, the idiosyncratic variance); the guess is a `NamedTuple` whose keys are the
+# unknown functions (`pA, pB, p`), holding one starting value at each grid point. These names are
+# what reappear inside the equation below — e.g. `pAx_up` will be the forward finite difference of
+# `pA` in `x`.
+#
+# Two helpers build a 30×30 grid over ``(x, \nu)`` and a flat guess. The variance state ``\nu``
+# follows a Gamma-distributed CIR process, so its grid spans that ergodic range.
 
 function initialize_stategrid(m::DiTellaModel; xn = 30, νn = 30)
   xs = range(0.01, 0.99, length = xn)
@@ -43,6 +57,21 @@ function initialize_y(m::DiTellaModel, stategrid)
   νn = length(stategrid[:ν])
   (; pA = 20 * ones(xn, νn), pB = 20 * ones(xn, νn), p = 20 * ones(xn, νn))
 end
+
+m = DiTellaModel()
+stategrid = initialize_stategrid(m)
+yend = initialize_y(m, stategrid)
+
+# ## The equation
+#
+# We now write the function encoding the equilibrium conditions. Following the package convention,
+# it takes the current `state` (a grid point) and `u` — the local bundle holding each unknown and
+# its finite-difference derivatives there — and returns the time derivative of each unknown
+# (`pAt, pBt, pt`).
+#
+# With two states, both first derivatives and the cross derivative are upwinded — the first
+# derivatives on the sign of their drifts, the cross term on the sign of the ``x``–``\nu``
+# covariance.
 
 function (m::DiTellaModel)(state::NamedTuple, u::NamedTuple)
   (; γ, ψ, ρ, τ, A, σ, ϕ, νbar, κν, σνbar) = m
@@ -99,15 +128,8 @@ function (m::DiTellaModel)(state::NamedTuple, u::NamedTuple)
   return (; pAt, pBt, pt)
 end
 
-# ## Solving it
-#
-# A 30×30 grid over ``(x, \nu)``. The variance state ``\nu`` follows a Gamma-distributed CIR
-# process, so its grid spans that ergodic range. `p` enters as an algebraic (constraint) variable,
-# and a small time step `Δ` is used.
+# `p` enters as an algebraic (constraint) variable, and a small time step `Δ` is used:
 
-m = DiTellaModel()
-stategrid = initialize_stategrid(m)
-yend = initialize_y(m, stategrid)
 result = pdesolve(m, stategrid, yend; is_algebraic = (; pA = false, pB = false, p = true), Δ = 1e-2)
 
 # ## The solution

--- a/examples/asset_pricing/garleanu_panageas.jl
+++ b/examples/asset_pricing/garleanu_panageas.jl
@@ -12,25 +12,52 @@
 # must be recomputed from the resulting drift ``\mu_x`` each iteration.
 
 # ## The model
+#
+# The parameters:
 
 using EconPDEs, Plots
 
 Base.@kwdef struct GarleanuPanageasModel
-    γA::Float64 = 1.5
-    ψA::Float64 = 0.7
-    γB::Float64 = 10.0
-    ψB::Float64 = 0.05
-    ρ::Float64 = 0.001
-    δ::Float64 = 0.02
-    νA::Float64 = 0.01
-    μ::Float64 = 0.02
-    σ::Float64 = 0.041
-    B1::Float64 = 30.72
-    δ1::Float64 = 0.0525
-    B2::Float64 = -30.29
-    δ2::Float64 = 0.0611
-    ω::Float64 = 0.92
+    γA::Float64 = 1.5      # relative risk aversion, type A (bold)
+    ψA::Float64 = 0.7      # elasticity of intertemporal substitution, type A
+    γB::Float64 = 10.0     # relative risk aversion, type B (conservative)
+    ψB::Float64 = 0.05     # elasticity of intertemporal substitution, type B
+    ρ::Float64 = 0.001     # rate of time preference (discount rate)
+    δ::Float64 = 0.02      # death (turnover) rate
+    νA::Float64 = 0.01     # share of type A among newborns
+    μ::Float64 = 0.02      # aggregate consumption growth (drift)
+    σ::Float64 = 0.041     # aggregate consumption volatility
+    B1::Float64 = 30.72    # loading on first component of labor-income profile
+    δ1::Float64 = 0.0525   # decay rate of first labor-income component
+    B2::Float64 = -30.29   # loading on second component of labor-income profile
+    δ2::Float64 = 0.0611   # decay rate of second labor-income component
+    ω::Float64 = 0.92      # labor share of aggregate output
 end
+
+# ## The state space
+#
+# We build the grid and the initial guess first, because they fix the names used everywhere else.
+# The grid is a `NamedTuple` whose key is the state variable (`x`, the consumption share of type
+# A); the guess is a `NamedTuple` whose keys are the unknown functions (`pA, pB, ϕ1, ϕ2`), holding
+# one starting value at each grid point. These names are what reappear inside the equation below —
+# e.g. `pAx_up` will be the forward finite difference of `pA` in `x`.
+#
+# One state ``x \in [0, 1]``, four coupled unknowns, all initialized flat at one.
+
+m = GarleanuPanageasModel()
+stategrid = (; x = range(0.0, 1.0, length = 100))
+yend = (; pA = ones(length(stategrid[:x])), pB = ones(length(stategrid[:x])), ϕ1 = ones(length(stategrid[:x])), ϕ2 = ones(length(stategrid[:x])))
+
+# ## The equation
+#
+# We now write the function encoding the equilibrium conditions. Following the package convention,
+# it takes the current `state` (a grid point) and `u` — the local bundle holding each unknown and
+# its finite-difference derivatives there — and returns the time derivative of each unknown
+# (`pAt, pBt, ϕ1t, ϕ2t`).
+#
+# Because ``\sigma_x`` is endogenous, the loop recomputes the upwind direction from the drift
+# ``\mu_x``: it starts with forward differences (`*_up`) and switches to backward (`*_down`) when
+# the drift turns negative.
 
 function (m::GarleanuPanageasModel)(state::NamedTuple, u::NamedTuple)
     (; γA, ψA, γB, ψB, ρ, δ, νA, μ, σ, B1, δ1, B2, δ2, ω) = m
@@ -80,14 +107,8 @@ function (m::GarleanuPanageasModel)(state::NamedTuple, u::NamedTuple)
     return (; pAt, pBt, ϕ1t, ϕ2t), (; r, κ)
 end
 
-# ## Solving it
-#
-# One state ``x \in [0, 1]`` (the consumption share of type A), four coupled unknowns, all
-# initialized flat at one.
+# With the equation, grid, and guess in hand, `pdesolve` solves the stationary system:
 
-m = GarleanuPanageasModel()
-stategrid = (; x = range(0.0, 1.0, length = 100))
-yend = (; pA = ones(length(stategrid[:x])), pB = ones(length(stategrid[:x])), ϕ1 = ones(length(stategrid[:x])), ϕ2 = ones(length(stategrid[:x])))
 result = pdesolve(m, stategrid, yend)
 
 # ## The solution

--- a/examples/asset_pricing/gomez.jl
+++ b/examples/asset_pricing/gomez.jl
@@ -8,36 +8,60 @@
 # entrepreneurs) keep the distribution stationary.
 
 # ## The model
+#
+# The parameters:
 
 using EconPDEs, Plots
 
 Base.@kwdef struct GomezModel
-    ## utility households
-    γ::Float64
-    ψ::Float64
-    ρ::Float64
+    ## utility, households
+    γ::Float64 = 10.3      # households' relative risk aversion
+    ψ::Float64 = 0.05      # households' elasticity of intertemporal substitution
+    ρ::Float64 = 0.1       # households' discount rate
 
-    ## utility entrepreneurs
-    ρE::Float64
-    αE::Float64
-    ν::Float64
+    ## utility, entrepreneurs
+    ρE::Float64 = 0.022    # entrepreneurs' discount rate
+    αE::Float64 = 2        # entrepreneurs' risk aversion
+    ν::Float64 = 0.1       # entrepreneurs' preference parameter
 
-    ## Demography
-    η::Float64
-    δ::Float64
-    ϕ::Float64
-    πE::Float64
+    ## demography
+    η::Float64 = 0.015     # birth rate
+    δ::Float64 = 0.025     # death rate
+    ϕ::Float64 = 0.01      # demographic transition rate
+    πE::Float64 = 0.09     # entry rate into entrepreneurship
 
-    ## Endowment process
-    g::Float64
-    σ::Float64
-    λ::Float64
-    τ::Float64
+    ## endowment process
+    g::Float64 = 0.02      # expected consumption growth
+    σ::Float64 = 0.04      # consumption volatility
+    λ::Float64 = 2.3       # endowment-process parameter
+    τ::Float64 = 0.0       # tax rate
 end
 
-function GomezModel(;γ = 10.3, ψ = 0.05, ρ = 0.1, ρE = 0.022, αE = 2, ν = 0.1, η = 0.015, δ = 0.025, ϕ = 0.01, πE = 0.09, g = 0.02, σ = 0.04,  λ = 2.3, τ = 0.0)
-  GomezModel(γ, ψ, ρ, ρE, αE, ν, η, δ, ϕ, πE, g, σ, λ, τ)
-end
+# ## The state space
+#
+# We build the grid and the initial guess first, because they fix the names used everywhere else.
+# The grid is a `NamedTuple` whose key is the state variable (`x`, the entrepreneurs' consumption
+# share); the guess is a `NamedTuple` whose key is the unknown function (`pH`), holding one
+# starting value at each grid point. These names are what reappear inside the equation below —
+# e.g. `pHx_up` will be the forward finite difference of `pH` in `x`.
+#
+# One state ``x \in [0, 1]`` on a squared grid of 300 points. The single unknown ``p_H`` is
+# initialized flat at one.
+
+m = GomezModel()
+stategrid = (; x = range(0, 1, 300) .^ 2)
+yend = (; pH = ones(length(stategrid[:x])))
+
+# ## The equation
+#
+# We now write the function encoding the equilibrium conditions. Following the package convention,
+# it takes the current `state` (a grid point) and `u` — the local bundle holding the unknown and
+# its finite-difference derivatives there — and returns the time derivative of the unknown
+# (`pHt`).
+#
+# The volatility of the state ``\sigma_x`` is endogenous, feeding back through prices, so the
+# upwind direction is picked from the drift ``\mu_x``: forward difference `pHx_up` unless the drift
+# turns negative, then backward `pHx_down`.
 
 function (m::GomezModel)(state, u)
   (; γ, ψ, ρ, ρE, αE, ν, η, δ, ϕ, πE, g, σ, λ, τ) = m
@@ -97,14 +121,8 @@ function (m::GomezModel)(state, u)
   return (; pHt,), (; x, μx, σx, κ, r, σWH, μWH, σp, p, px, σR, μR, μRλ, σRλ, μErelative, σErelative, μHrelative, σHrelative, μCE, μxW, σxW, pH, μCH, wedge, xW, σWE, σCH, αE, pE = 1 / m.ρE, μp = μp)
 end
 
-# ## Solving it
-#
-# One state ``x \in [0, 1]``, the entrepreneurs' consumption share, on 300 grid points. The single
-# unknown ``p_H`` is initialized flat at one.
+# With the equation, grid, and guess in hand, `pdesolve` solves the stationary system:
 
-m = GomezModel()
-stategrid = (; x = range(0, 1, 300))
-yend = (; pH = ones(length(stategrid[:x])))
 @time result = pdesolve(m, stategrid, yend)
 
 # ## The solution

--- a/examples/asset_pricing/haddad.jl
+++ b/examples/asset_pricing/haddad.jl
@@ -17,27 +17,58 @@
 # mean-reverting square-root processes.
 
 # ## The model
+#
+# The parameters live in a `struct`:
 
 using EconPDEs, Distributions, Plots
 
 Base.@kwdef struct HaddadModel
   ## consumption process parameters
-  μbar::Float64 = 0.018
-  vbar::Float64 = 0.00052
-  κμ::Float64 = 0.3
-  νμ::Float64 = 0.456
-  κv::Float64 = 0.012
-  νv::Float64 = 0.00472
+  μbar::Float64 = 0.018     # long-run mean of expected consumption growth μ
+  vbar::Float64 = 0.00052   # long-run mean of consumption variance v
+  κμ::Float64 = 0.3         # mean-reversion speed of μ
+  νμ::Float64 = 0.456       # volatility loading of the μ process
+  κv::Float64 = 0.012       # mean-reversion speed of v
+  νv::Float64 = 0.00472     # volatility loading of the v process
 
   ## active capital
-  αbar::Float64 = 1.2
-  λ::Float64 = 0.018
+  αbar::Float64 = 1.2       # maximum active-capital share
+  λ::Float64 = 0.018        # cost of active participation (ownership friction)
 
   ## utility parameters
-  ρ::Float64 = 0.0132
-  γ::Float64 = 10.0
-  ψ::Float64 = 1.5
+  ρ::Float64 = 0.0132       # rate of time preference (discount rate)
+  γ::Float64 = 10.0         # relative risk aversion
+  ψ::Float64 = 1.5          # elasticity of intertemporal substitution
 end
+
+# ## The state space
+#
+# We build the grid and the initial guess first, because they fix the names used everywhere
+# else. This model has two state variables, so the grid is a `NamedTuple` with two keys (`μ` and
+# `v`); the guess is a `NamedTuple` whose key is the unknown function (`p`, the price–consumption
+# ratio), a matrix over the ``(\mu, v)`` grid. These names reappear inside the equation below —
+# e.g. `pμ_up` is the forward finite difference of `p` in `μ`, and `pμv` is the cross-partial. The
+# grid spans the ergodic ranges of ``\mu`` (Normal) and ``v`` (Gamma). The ``\sqrt v`` diffusion
+# vanishes at ``v = 0``, a degenerate boundary where no condition is imposed.
+
+m = HaddadModel()
+σ = sqrt(m.νμ^2 * m.vbar / (2 * m.κμ))
+μmin = quantile(Normal(m.μbar, σ), 0.001)
+μmax = quantile(Normal(m.μbar, σ), 0.999)
+μs = range(μmin,  μmax, length = 30)
+α = 2 * m.κv * m.vbar / m.νv^2
+β = m.νv^2 / (2 * m.κv)
+vmin = quantile(Gamma(α, β), 0.001)
+vmax = quantile(Gamma(α, β), 0.999)
+vs = range(vmin,  vmax, length = 30)
+stategrid = (; μ = μs, v = vs)
+yend =   (; p = ones(length(stategrid[:μ]), length(stategrid[:v])))
+
+# ## The equation
+#
+# We now write the function encoding the HJB equation. Following the package convention, it
+# takes the current `state` (a grid point) and `u` (each unknown together with its
+# finite-difference derivatives there) and returns the time derivative of each unknown.
 
 function (m::HaddadModel)(state::NamedTuple, u::NamedTuple)
   (; μbar, vbar, κμ, νμ, κv, νv, αbar, λ, ρ, γ, ψ) = m
@@ -72,23 +103,8 @@ function (m::HaddadModel)(state::NamedTuple, u::NamedTuple)
   return (; pt)
 end
 
-# ## Solving it
-#
-# The grid spans the ergodic ranges of ``\mu`` (Normal) and ``v`` (Gamma). The ``\sqrt v``
-# diffusion vanishes at ``v = 0``, a degenerate boundary where no condition is imposed.
+# With the equation, grid, and guess in hand, `pdesolve` solves the stationary system:
 
-m = HaddadModel()
-σ = sqrt(m.νμ^2 * m.vbar / (2 * m.κμ))
-μmin = quantile(Normal(m.μbar, σ), 0.001)
-μmax = quantile(Normal(m.μbar, σ), 0.999)
-μs = range(μmin,  μmax, length = 30)
-α = 2 * m.κv * m.vbar / m.νv^2
-β = m.νv^2 / (2 * m.κv)
-vmin = quantile(Gamma(α, β), 0.001)
-vmax = quantile(Gamma(α, β), 0.999)
-vs = range(vmin,  vmax, length = 30)
-stategrid = (; μ = μs, v = vs)
-yend =   (; p = ones(length(stategrid[:μ]), length(stategrid[:v])))
 result = pdesolve(m, stategrid, yend)
 
 # ## The solution

--- a/examples/asset_pricing/he_krishnamurthy.jl
+++ b/examples/asset_pricing/he_krishnamurthy.jl
@@ -8,6 +8,8 @@
 # ties the aggregate price–consumption ratio ``p`` to it.
 
 # ## The model
+#
+# The parameters:
 
 using EconPDEs, Plots
 
@@ -21,6 +23,34 @@ Base.@kwdef mutable struct HeKrishnamurthy
   γ::Float64 = 2.0 # risk aversion specialist
   l::Float64 = 1.84 # labor income ratio
 end
+
+# ## The state space
+#
+# We build the grid and the initial guess first, because they fix the names used everywhere else.
+# The grid is a `NamedTuple` whose key is the state variable (`x`, the specialists' wealth share);
+# the guess is a `NamedTuple` whose key is the unknown function (`pS`), holding one starting value
+# at each grid point. These names are what reappear inside the equation below — e.g. `pSx_up` will
+# be the forward finite difference of `pS` in `x`.
+#
+# One state ``x \in (0, 1)`` on a grid stretched toward the lower boundary where the constraint
+# bites. The single unknown ``p_S`` is initialized flat at one.
+
+m = HeKrishnamurthy()
+xn = 100
+stategrid =  (; x = range(0, 1, length = xn+2)[2:(end-1)].^1.5)
+yend = (; pS = ones(length(stategrid[:x])))
+
+# ## The equation
+#
+# We now write the function encoding the equilibrium conditions. Following the package convention,
+# it takes the current `state` (a grid point) and `u` — the local bundle holding the unknown and
+# its finite-difference derivatives there (`pS`, `pSx_up`, `pSx_down`, `pSxx`) — and returns the
+# time derivative `pSt`.
+#
+# Goods-market clearing expresses the aggregate price–consumption ratio ``p`` (and its
+# derivatives) in terms of ``p_S``. The state volatility ``\sigma_x`` feeds back through prices, so
+# the upwind direction is chosen from the drift ``\mu_x``: forward `pSx_up` unless the drift turns
+# negative, then backward `pSx_down`.
 
 function (m::HeKrishnamurthy)(state::NamedTuple, u::NamedTuple)
   (; m, λ, g, σ, ρ, γ, l) = m
@@ -66,15 +96,8 @@ function (m::HeKrishnamurthy)(state::NamedTuple, u::NamedTuple)
   (; pSt), (; pS, p, r, κ, σp, μR, σR, αI, μx, σx, x, px, pxx, σI)
 end
 
-# ## Solving it
-#
-# One state ``x \in (0, 1)``, the specialists' wealth share, on a grid stretched toward the lower
-# boundary where the constraint bites. The single unknown ``p_S`` is initialized flat at one.
+# With the equation, grid, and guess in hand, `pdesolve` solves the stationary system:
 
-m = HeKrishnamurthy()
-xn = 100
-stategrid =  (; x = range(0, 1, length = xn+2)[2:(end-1)].^1.5)
-yend = (; pS = ones(length(stategrid[:x])))
 result = pdesolve(m, stategrid, yend)
 
 # ## The solution

--- a/examples/asset_pricing/tuckman_vila.jl
+++ b/examples/asset_pricing/tuckman_vila.jl
@@ -12,17 +12,29 @@
 # ```
 
 # ## The model
+#
+# The parameters live in a `struct`:
 
 using EconPDEs, Distributions, Plots
 
 Base.@kwdef struct TuckmanVilaModel
-    c::Float64 = 0.06
-    r::Float64 = 0.09
-    ρ::Float64 = 5.42
-    σ::Float64 = 26.72
-    a::Float64 = 26.72
-    T::Float64 = 100
+    c::Float64 = 0.06     # coupon rate of the bond
+    r::Float64 = 0.09     # risk-free rate
+    ρ::Float64 = 5.42     # mean-reversion speed of the state z
+    σ::Float64 = 26.72    # volatility of the state z
+    a::Float64 = 26.72    # position (holding-cost) scaling parameter
+    T::Float64 = 100      # horizon (terminal date)
 end
+
+# ## The state space
+#
+# We build the grid, the initial guess, and the time grid first, because they fix the names used
+# everywhere else. The grid is a `NamedTuple` whose key is the state variable (`z`); the guess is
+# a `NamedTuple` whose key is the unknown function (`F`), which here doubles as the terminal
+# condition at `τs[end]`. These names reappear inside the equation below — e.g. `Fz_up` is the
+# forward finite difference of `F` in `z`. The grid spans the stationary range of ``z`` (a
+# mean-reverting Gaussian). Because the problem is finite-horizon, we also build a time grid `τs`
+# over ``[0, T]``, which `pdesolve` will march backward along.
 
 function initialize_stategrid(m::TuckmanVilaModel; zn = 200)
     d = Normal(0, sqrt(m.σ^2 / (2 * m.ρ)))
@@ -33,6 +45,18 @@ function initialize_y(m::TuckmanVilaModel, stategrid)
     zn = length(stategrid[:z])
     (; F = zeros(zn))
 end
+
+m = TuckmanVilaModel()
+stategrid = initialize_stategrid(m)
+yend = initialize_y(m, stategrid)
+τs = range(0, m.T, length = 10)
+
+# ## The equation
+#
+# We now write the function encoding the HJB equation. Following the package convention, it
+# takes the current `state` (a grid point) and `u` (each unknown together with its
+# finite-difference derivatives there) and returns the time derivative of each unknown. Because
+# the problem is time-dependent, it also takes a third argument, the time `τ`.
 
 function (m::TuckmanVilaModel)(state::NamedTuple, u::NamedTuple, τ::Number)
     (; c, r, ρ, σ, a, T) = m
@@ -57,14 +81,9 @@ function (m::TuckmanVilaModel)(state::NamedTuple, u::NamedTuple, τ::Number)
     return (; Ft)
 end
 
-# ## Solving it
-#
-# `yend` is the terminal value at `τs[end]`; `pdesolve` marches backward over `τs`.
+# `pdesolve` takes the time grid `τs` as a fourth argument and marches backward from the terminal
+# condition:
 
-m = TuckmanVilaModel()
-stategrid = initialize_stategrid(m)
-yend = initialize_y(m, stategrid)
-τs = range(0, m.T, length = 10)
 result = pdesolve(m, stategrid, yend, τs)
 
 # ## The solution

--- a/examples/asset_pricing/wachter.jl
+++ b/examples/asset_pricing/wachter.jl
@@ -15,26 +15,57 @@
 # consumption is smooth outside disasters.
 
 # ## The model
+#
+# The parameters live in a `struct`:
 
 using EconPDEs, Distributions, Plots
 
 Base.@kwdef struct WachterModel{T<: Distribution}
     ## consumption process parameters
-    μ::Float64 = 0.025
-    σ::Float64 = 0.02
+    μ::Float64 = 0.025      # expected consumption growth
+    σ::Float64 = 0.02       # volatility of consumption growth
 
     ## disaster process parameters
-    λbar::Float64 = 0.0355
-    κλ::Float64 = 0.08
-    νλ::Float64 = 0.067
-    ZDistribution::T = Normal(-0.4, 0.25) # from Ian Martin higher order cumulants paper
+    λbar::Float64 = 0.0355  # long-run mean disaster intensity
+    κλ::Float64 = 0.08      # mean-reversion speed of disaster intensity
+    νλ::Float64 = 0.067     # volatility of disaster intensity
+    ZDistribution::T = Normal(-0.4, 0.25) # distribution of disaster jump size Z (log consumption drop); from Ian Martin higher order cumulants paper
 
     ## utility parameters
-    ρ::Float64 = 0.012
-    γ::Float64 = 3.0
-    ψ::Float64 = 1.1
-    ϕ::Float64 = 2.6
+    ρ::Float64 = 0.012      # discount rate
+    γ::Float64 = 3.0        # relative risk aversion
+    ψ::Float64 = 1.1        # elasticity of intertemporal substitution
+    ϕ::Float64 = 2.6        # leverage of dividends on consumption
 end
+
+# ## The state space
+#
+# We build the grid and the initial guess first, because they fix the names used everywhere
+# else. The grid is a `NamedTuple` whose key is the state variable (`λ`, the disaster
+# intensity); the guess is a `NamedTuple` whose key is the unknown function (`p`, the
+# wealth–consumption ratio). These names reappear inside the equation below — e.g. `pλ_up` will
+# be the forward finite difference of `p` in `λ`. The state ``\lambda`` ranges over intensities
+# from zero up to well above its long-run mean ``\bar\lambda``. The ``\sqrt\lambda`` diffusion
+# vanishes at ``\lambda = 0``, a degenerate boundary where no condition is imposed.
+
+function initialize_stategrid(m::WachterModel; λn = 30)
+  (; λ = range(0.0, 0.1, length = λn))
+end
+
+function initialize_y(m::WachterModel, stategrid)
+    λn = length(stategrid[:λ])
+    (; p = ones(λn))
+end
+
+m = WachterModel()
+stategrid = initialize_stategrid(m)
+yend = initialize_y(m, stategrid)
+
+# ## The equation
+#
+# We now write the function encoding the HJB equation. Following the package convention, it
+# takes the current `state` (a grid point) and `u` (each unknown together with its
+# finite-difference derivatives there) and returns the time derivative of each unknown.
 
 function (m::WachterModel)(state::NamedTuple, u::NamedTuple)
     (; μ, σ, λbar, κλ, νλ, ZDistribution, ρ, γ, ψ, ϕ) = m
@@ -63,24 +94,8 @@ function (m::WachterModel)(state::NamedTuple, u::NamedTuple)
     return (; pt)
 end
 
-# ## Solving it
-#
-# The state ``\lambda`` ranges over intensities from zero up to well above its long-run mean
-# ``\bar\lambda``. The ``\sqrt\lambda`` diffusion vanishes at ``\lambda = 0``, a degenerate
-# boundary where no condition is imposed.
+# With the equation, grid, and guess in hand, `pdesolve` solves the stationary system:
 
-function initialize_stategrid(m::WachterModel; λn = 30)
-  (; λ = range(0.0, 0.1, length = λn))
-end
-
-function initialize_y(m::WachterModel, stategrid)
-    λn = length(stategrid[:λ])
-    (; p = ones(λn))
-end
-
-m = WachterModel()
-stategrid = initialize_stategrid(m)
-yend = initialize_y(m, stategrid)
 result = pdesolve(m, stategrid, yend)
 
 # ## The solution

--- a/examples/consumption_saving/consumption_saving_one_asset.jl
+++ b/examples/consumption_saving/consumption_saving_one_asset.jl
@@ -17,29 +17,47 @@
 # ``a \ge a_{\min}`` enforced as a state constraint (saving cannot be negative at the limit).
 
 # ## The model
+#
+# The parameters live in a `struct`:
 
 using EconPDEs, Distributions, Plots
 
-struct AchdouHanLasryLionsMollModel_Diffusion
-    ## income process parameters
-    κy::Float64
-    ybar::Float64
-    σy::Float64
-
-    r::Float64
-
-    ## utility parameters
-    ρ::Float64
-    γ::Float64
-
-    amin::Float64
-    amax::Float64
+Base.@kwdef struct AchdouHanLasryLionsMollModel_Diffusion
+    κy::Float64 = 0.1      # income mean-reversion speed
+    ybar::Float64 = 1.0    # mean income level
+    σy::Float64 = 0.07     # income volatility
+    r::Float64 = 0.03      # risk-free rate
+    ρ::Float64 = 0.05      # discount rate
+    γ::Float64 = 2.0       # relative risk aversion
+    amin::Float64 = 0.0    # borrowing limit
+    amax::Float64 = 500.0  # top of the asset grid
 end
 
-function AchdouHanLasryLionsMollModel_Diffusion(;κy = 0.1, ybar = 1.0, σy = 0.07, r = 0.03, ρ = 0.05, γ = 2.0, amin = 0.0, amax = 500.0)
-    AchdouHanLasryLionsMollModel_Diffusion(κy, ybar, σy, r, ρ, γ, amin, amax)
-end
+# ## The state space
+#
+# We build the grid and the initial guess first, because they fix the names used everywhere
+# else. The grid is a `NamedTuple` whose keys are the two state variables (`y` and `a`); the
+# guess is a `NamedTuple` whose key is the unknown function (`v`), holding one starting value at
+# each grid point. These names are what reappear inside the equation below — e.g. `va_up` will
+# be the forward finite difference of `v` in `a`.
+#
+# Income lives on a grid spanning the bulk of its ergodic (Gamma) distribution, and assets on a
+# grid from the borrowing limit up to ``a_{\max}``. The initial guess is the value of consuming
+# the annuity value of total wealth ``a + y/r`` forever.
 
+m = AchdouHanLasryLionsMollModel_Diffusion()
+distribution = Gamma(2 * m.κy * m.ybar / m.σy^2, m.σy^2 / (2 * m.κy))
+stategrid = (; y = range(quantile(distribution, 0.001), quantile(distribution, 0.999), length = 10),
+                        a =  range(m.amin, m.amax, length = 200)
+                        )
+yend = (; v = [(m.ρ / m.γ + (1 - 1 / m.γ) * m.r)^(-m.γ) * (a + y / m.r)^(1 - m.γ) / (1 - m.γ) for y in stategrid[:y], a in stategrid[:a]])
+
+# ## The equation
+#
+# We now write the function encoding the HJB equation. Following the package convention, it
+# takes the current `state` (a grid point) and `u` (each unknown together with its
+# finite-difference derivatives there) and returns the time derivative of each unknown.
+#
 # Income drift is exogenous, so its derivative is upwinded on the sign of ``\mu_y``. The asset
 # drift ``\mu_a = y + r a - c`` is endogenous: we try the forward derivative, fall back to the
 # backward one, and — when both fail or the borrowing constraint binds — set ``\mu_a = 0`` and
@@ -82,18 +100,8 @@ function (m::AchdouHanLasryLionsMollModel_Diffusion)(state::NamedTuple, u::Named
     return (; vt), (; μa, c)
 end
 
-# ## Solving it
-#
-# Income lives on a grid spanning the bulk of its ergodic (Gamma) distribution, and assets on a
-# grid from the borrowing limit up to ``a_{\max}``. The initial guess is the value of consuming
-# the annuity value of total wealth ``a + y/r`` forever.
+# With the equation, grid, and guess in hand, `pdesolve` solves the stationary system:
 
-m = AchdouHanLasryLionsMollModel_Diffusion()
-distribution = Gamma(2 * m.κy * m.ybar / m.σy^2, m.σy^2 / (2 * m.κy))
-stategrid = (; y = range(quantile(distribution, 0.001), quantile(distribution, 0.999), length = 10),
-                        a =  range(m.amin, m.amax, length = 200)
-                        )
-yend = (; v = [(m.ρ / m.γ + (1 - 1 / m.γ) * m.r)^(-m.γ) * (a + y / m.r)^(1 - m.γ) / (1 - m.γ) for y in stategrid[:y], a in stategrid[:a]])
 result = pdesolve(m, stategrid, yend)
 
 # ## The solution
@@ -103,17 +111,18 @@ result = pdesolve(m, stategrid, yend)
 
 as = stategrid[:a]
 ys = stategrid[:y]
+idx = 1:div(length(as), 3)          # left third of the asset grid, where the curvature is
 iys = round.(Int, range(1, length(ys), length = 3))
 μa = result.optional[:μa]
 c = result.optional[:c]
 
 p1 = plot(xlabel = "assets a", ylabel = "consumption c")
 for iy in iys
-    plot!(p1, as, c[iy, :], label = "y = $(round(ys[iy], digits = 2))")
+    plot!(p1, as[idx], c[iy, idx], label = "y = $(round(ys[iy], digits = 2))")
 end
 p2 = plot(xlabel = "assets a", ylabel = "saving μa")
 for iy in iys
-    plot!(p2, as, μa[iy, :], label = "y = $(round(ys[iy], digits = 2))")
+    plot!(p2, as[idx], μa[iy, idx], label = "y = $(round(ys[iy], digits = 2))")
 end
 hline!(p2, [0.0]; color = :gray, linestyle = :dash, label = "")
 plot(p1, p2; layout = (1, 2), size = (800, 300))

--- a/examples/consumption_saving/consumption_saving_two_assets.jl
+++ b/examples/consumption_saving/consumption_saving_two_assets.jl
@@ -21,27 +21,52 @@
 # holding, clamped to ``[0, a - a_{\min}]``.
 
 # ## The model
+#
+# The parameters live in a `struct`:
 
 using EconPDEs, Distributions, Plots
 
 Base.@kwdef struct AchdouHanLasryLionsMoll_DiffusionTwoAssetsModel
-    ## income process parameters
-    κy::Float64 = 0.1
-    ybar::Float64 = 1.0
-    σy::Float64 = 0.07
+    κy::Float64 = 0.1        # mean-reversion speed of labor income
+    ybar::Float64 = 1.0      # long-run mean of labor income
+    σy::Float64 = 0.07       # volatility of labor income
 
-    r::Float64 = 0.03
-    μR::Float64 = 0.04
-    σR::Float64 = 0.1
+    r::Float64 = 0.03        # risk-free rate
+    μR::Float64 = 0.04       # expected return on the risky asset
+    σR::Float64 = 0.1        # volatility of the risky asset
 
-    ## utility parameters
-    ρ::Float64 = 0.05
-    γ::Float64 = 2.0
+    ρ::Float64 = 0.05        # discount rate
+    γ::Float64 = 2.0         # relative risk aversion
 
-    amin::Float64 = 0.0
-    amax::Float64 = 1000.0
+    amin::Float64 = 0.0      # borrowing limit (minimum wealth)
+    amax::Float64 = 1000.0   # maximum wealth (grid upper bound)
 end
 
+# ## The state space
+#
+# We build the grid and the initial guess first, because they fix the names used everywhere
+# else. The grid is a `NamedTuple` whose keys are the two state variables (`y` and `a`); the
+# guess is a `NamedTuple` whose key is the unknown function (`v`), holding one starting value at
+# each grid point. These names are what reappear inside the equation below — e.g. `va_up` will
+# be the forward finite difference of `v` in `a`.
+#
+# Income spans the bulk of its ergodic (Gamma) distribution and wealth runs from the borrowing
+# limit up to ``a_{\max}``. As before, the initial guess is the value of consuming the annuity
+# value of total wealth ``a + y/r`` forever.
+
+m = AchdouHanLasryLionsMoll_DiffusionTwoAssetsModel()
+distribution = Gamma(2 * m.κy * m.ybar / m.σy^2, m.σy^2 / (2 * m.κy))
+ys = range(quantile(distribution, 0.001), quantile(distribution, 0.999), length = 5)
+as = range(m.amin, m.amax, length = 100)
+stategrid = (; y = ys, a = as)
+yend = (; v = [(m.ρ / m.γ + (1 - 1 / m.γ) * m.r)^(-m.γ) * (a + y / m.r)^(1 - m.γ) / (1 - m.γ) for y in stategrid[:y], a in stategrid[:a]])
+
+# ## The equation
+#
+# We now write the function encoding the HJB equation. Following the package convention, it
+# takes the current `state` (a grid point) and `u` (each unknown together with its
+# finite-difference derivatives there) and returns the time derivative of each unknown.
+#
 # As in the one-asset model, income is upwinded on ``\mu_y`` and the endogenous asset drift picks
 # the forward/backward derivative that keeps its sign consistent. At each candidate we also solve
 # the Merton portfolio rule for ``k``. The boundary branches impose the borrowing constraint at
@@ -122,19 +147,8 @@ function (m::AchdouHanLasryLionsMoll_DiffusionTwoAssetsModel)(state::NamedTuple,
     return (; vt), (; v, c, k, va, vaa, vy, y, a, μa)
 end
 
+# With the equation, grid, and guess in hand, `pdesolve` solves the stationary system:
 
-# ## Solving it
-#
-# Income spans the bulk of its ergodic (Gamma) distribution and wealth runs from the borrowing
-# limit up to ``a_{\max}``. As before, the initial guess is the value of consuming the annuity
-# value of total wealth ``a + y/r`` forever.
-
-m = AchdouHanLasryLionsMoll_DiffusionTwoAssetsModel()
-distribution = Gamma(2 * m.κy * m.ybar / m.σy^2, m.σy^2 / (2 * m.κy))
-ys = range(quantile(distribution, 0.001), quantile(distribution, 0.999), length = 5)
-as = range(m.amin, m.amax, length = 100)
-stategrid = (; y = ys, a = as)
-yend = (; v = [(m.ρ / m.γ + (1 - 1 / m.γ) * m.r)^(-m.γ) * (a + y / m.r)^(1 - m.γ) / (1 - m.γ) for y in stategrid[:y], a in stategrid[:a]])
 result = pdesolve(m, stategrid, yend)
 
 # ## The solution
@@ -143,21 +157,22 @@ result = pdesolve(m, stategrid, yend)
 
 as = stategrid[:a]
 ys = stategrid[:y]
+idx = 1:div(length(as), 3)          # left third of the wealth grid, where the curvature is
 iys = round.(Int, range(1, length(ys), length = 3))
 
 p1 = plot(xlabel = "wealth a", ylabel = "consumption c")
 for iy in iys
-    plot!(p1, as, result.optional[:c][iy, :], label = "y = $(round(ys[iy], digits = 2))")
+    plot!(p1, as[idx], result.optional[:c][iy, idx], label = "y = $(round(ys[iy], digits = 2))")
 end
-p2 = plot(xlabel = "wealth a", ylabel = "risky holding k")
+p2 = plot(xlabel = "wealth a", ylabel = "saving μa")
 for iy in iys
-    plot!(p2, as, result.optional[:k][iy, :], label = "y = $(round(ys[iy], digits = 2))")
+    plot!(p2, as[idx], result.optional[:μa][iy, idx], label = "y = $(round(ys[iy], digits = 2))")
 end
+hline!(p2, [0.0]; color = :gray, linestyle = :dash, label = "")
 plot(p1, p2; layout = (1, 2), size = (800, 300))
 
-# Consumption rises with both wealth and income (left). The risky holding (right) is
-# approximately linear in wealth, tracking the Merton fraction ``(\mu_R - r)/(\gamma\sigma_R^2)``
-# of wealth once the household is far from the borrowing constraint. Near the constraint the
-# household tilts toward the safe asset: it cannot lever, and undiversifiable labor-income risk
-# crowds out financial risk-taking, so the poorest households hold almost none of the risky asset
-# even though its Sharpe ratio is positive.
+# Consumption rises with both wealth and income (left); the saving rate (right) is highest for the
+# wealth-poor and turns negative as households approach their target wealth. On the portfolio side
+# (not shown), away from the constraint the household holds the Merton fraction
+# ``(\mu_R - r)/(\gamma\sigma_R^2)`` of wealth in the risky asset, and tilts toward the safe asset
+# near the constraint, where it cannot lever and labor-income risk crowds out financial risk-taking.

--- a/examples/consumption_saving/consumption_saving_two_income_states.jl
+++ b/examples/consumption_saving/consumption_saving_two_income_states.jl
@@ -14,25 +14,49 @@
 # from turning negative at the lower bound.
 
 # ## The model
+#
+# The parameters live in a `struct`:
 
 using EconPDEs, Plots
 
-mutable struct AchdouHanLasryLionsMoll_TwoStatesModel
-    yl::Float64
-    yh::Float64
-    λlh::Float64
-    λhl::Float64
-    r::Float64
-    ρ::Float64
-    γ::Float64
-    amin::Float64
-    amax::Float64
+Base.@kwdef mutable struct AchdouHanLasryLionsMoll_TwoStatesModel
+    yl::Float64 = 0.5        # low income state
+    yh::Float64 = 1.5        # high income state
+    λlh::Float64 = 0.2       # low → high transition intensity
+    λhl::Float64 = 0.2       # high → low transition intensity
+    r::Float64 = 0.03        # risk-free rate
+    ρ::Float64 = 0.04        # discount rate
+    γ::Float64 = 2.0         # relative risk aversion
+    amin::Float64 = -yl / r  # borrowing limit (natural limit)
+    amax::Float64 = 50.0     # top of the asset grid
 end
 
-function AchdouHanLasryLionsMoll_TwoStatesModel(; yl = 0.5, yh = 1.5, λlh = 0.2, λhl = 0.2, r = 0.03, ρ = 0.04, γ = 2.0, amin = -yl / r, amax = 50.0)
-    AchdouHanLasryLionsMoll_TwoStatesModel(yl, yh, λlh, λhl, r, ρ, γ, amin, amax)
-end
+# ## The state space
+#
+# We build the grid and the initial guess first, because they fix the names used everywhere
+# else. The grid is a `NamedTuple` whose key is the single continuous state (`a`); the guess is a
+# `NamedTuple` whose keys are the two unknown functions (`vl` and `vh`), one starting value per
+# grid point. These names are what reappear inside the equation below — e.g. `vla_up` will be the
+# forward finite difference of `vl` in `a`.
+#
+# The asset grid is finer near the borrowing limit, and we start from an autarky-style guess. The
+# borrowing limit itself is nudged just inside the natural limit ``-y_l/r`` to keep consumption
+# strictly positive there.
 
+m = AchdouHanLasryLionsMoll_TwoStatesModel()
+m.amin += 0.001
+stategrid = (; a = m.amin .+ range(0, (m.amax - m.amin)^(1 / 2), length = 200) .^ 2)
+yend = (;
+    vl = (m.ρ ./ m.γ .+ (1 .- 1 / m.γ) .* m.r)^(-m.γ) .* (stategrid[:a] .+ m.yl ./ m.r) .^ (1 - m.γ) ./ (1 - m.γ),
+    vh = (m.ρ ./ m.γ .+ (1 .- m.γ) .* m.r)^(-m.γ) .* (stategrid[:a] .+ m.yh ./ m.r) .^ (1 - m.γ) ./ (1 - m.γ),
+)
+
+# ## The equation
+#
+# We now write the function encoding the HJB equation. Following the package convention, it
+# takes the current `state` (a grid point) and `u` (each unknown together with its
+# finite-difference derivatives there) and returns the time derivative of each unknown.
+#
 # In each income state we upwind the asset drift on its sign, capping the implied consumption
 # rather than flooring the marginal value (Newton may try negative marginal values). At the
 # borrowing constraint the drift is set to zero. We save consumption `cl`, `ch` to plot.
@@ -83,29 +107,19 @@ function (m::AchdouHanLasryLionsMoll_TwoStatesModel)(state::NamedTuple, u::Named
     return (; vlt, vht), (; cl, ch, μla, μha)
 end
 
-# ## Solving it
-#
-# Build the asset grid (finer near the borrowing limit), start from an autarky-style guess,
-# and solve.
+# With the equation, grid, and guess in hand, `pdesolve` solves the stationary system:
 
-m = AchdouHanLasryLionsMoll_TwoStatesModel()
-m.amin += 0.001
-stategrid = (; a = m.amin .+ range(0, (m.amax - m.amin)^(1 / 2), length = 200) .^ 2)
-yend = (;
-    vl = (m.ρ ./ m.γ .+ (1 .- 1 / m.γ) .* m.r)^(-m.γ) .* (stategrid[:a] .+ m.yl ./ m.r) .^ (1 - m.γ) ./ (1 - m.γ),
-    vh = (m.ρ ./ m.γ .+ (1 .- m.γ) .* m.r)^(-m.γ) .* (stategrid[:a] .+ m.yh ./ m.r) .^ (1 - m.γ) ./ (1 - m.γ),
-)
 result = pdesolve(m, stategrid, yend)
 
 # ## The solution
 #
-# The value function is higher in the high-income state (left). Consumption rises with wealth
-# in both states and is higher when income is high (right). Near the borrowing limit the
-# low-income household is forced to consume its income ``y_l + r a`` — the constraint binds and
-# precautionary saving disappears.
+# Consumption rises with wealth in both income states and is higher when income is high (left).
+# The saving rate (right) is pinned at zero at the borrowing limit for the low-income household —
+# which is forced to consume its income ``y_l + r a`` — and turns positive as wealth rises.
 
 as = stategrid[:a]
-mask = as .<= 5.0
-p1 = plot(as[mask], [result.zero[:vl][mask] result.zero[:vh][mask]]; label = ["low income" "high income"], xlabel = "assets a", ylabel = "value v(a)", legend = :bottomright)
-p2 = plot(as[mask], [result.optional[:cl][mask] result.optional[:ch][mask]]; label = ["low income" "high income"], xlabel = "assets a", ylabel = "consumption c(a)", legend = :bottomright)
+idx = 1:div(length(as), 3)          # left third of the asset grid, where the curvature is
+p1 = plot(as[idx], [result.optional[:cl][idx] result.optional[:ch][idx]]; label = ["low income" "high income"], xlabel = "assets a", ylabel = "consumption c(a)", legend = :bottomright)
+p2 = plot(as[idx], [result.optional[:μla][idx] result.optional[:μha][idx]]; label = ["low income" "high income"], xlabel = "assets a", ylabel = "saving μa(a)", legend = :topright)
+hline!(p2, [0.0]; color = :gray, linestyle = :dash, label = "")
 plot(p1, p2; layout = (1, 2), size = (800, 300))

--- a/examples/consumption_saving/wang_wang_yang.jl
+++ b/examples/consumption_saving/wang_wang_yang.jl
@@ -18,20 +18,44 @@
 # with the consumption–income ratio recovered from ``c = (r + \psi(\rho - r))\, p\, p'^{-\psi}``.
 
 # ## The model
+#
+# The parameters live in a `struct`:
 
 using EconPDEs, Plots
 
 Base.@kwdef mutable struct WangWangYangModel
-    μ::Float64 = 0.015
-    σ::Float64 = 0.1
-    r::Float64 = 0.035
-    ρ::Float64 = 0.04
-    γ::Float64 = 3.0
-    ψ::Float64 = 1.1
-    wmin::Float64 = 0.0
-    wmax::Float64 = 1000.0
+    μ::Float64 = 0.015       # expected growth rate of labor income
+    σ::Float64 = 0.1         # volatility of labor income
+    r::Float64 = 0.035       # risk-free rate
+    ρ::Float64 = 0.04        # discount rate
+    γ::Float64 = 3.0         # relative risk aversion
+    ψ::Float64 = 1.1         # elasticity of intertemporal substitution
+    wmin::Float64 = 0.0      # borrowing limit (minimum wealth-income ratio)
+    wmax::Float64 = 1000.0   # maximum wealth-income ratio (grid upper bound)
 end
 
+# ## The state space
+#
+# We build the grid and the initial guess first, because they fix the names used everywhere
+# else. The grid is a `NamedTuple` whose key is the state variable (`w`, the wealth-to-income
+# ratio); the guess is a `NamedTuple` whose key is the unknown function (`p`), one starting value
+# per grid point. These names are what reappear inside the equation below — e.g. `pw_up` will be
+# the forward finite difference of `p` in `w`.
+#
+# The state ``w`` runs from the borrowing limit to a large upper bound on a grid that is denser
+# near the constraint. The initial guess ``p = 1 + w`` reflects total wealth as financial plus
+# one unit of human wealth.
+
+m = WangWangYangModel()
+stategrid = (; w = range(m.wmin^(1/2), m.wmax^(1/2), length = 100).^2)
+yend = (; p = 1 .+ stategrid[:w])
+
+# ## The equation
+#
+# We now write the function encoding the HJB equation. Following the package convention, it
+# takes the current `state` (a grid point) and `u` (each unknown together with its
+# finite-difference derivatives there) and returns the time derivative of each unknown.
+#
 # We upwind on the physical wealth drift ``\mu_w`` of the controlled state, falling back to
 # ``\mu_w = 0`` when the borrowing constraint binds.
 
@@ -66,32 +90,26 @@ function (m::WangWangYangModel)(state::NamedTuple, u::NamedTuple)
     end
     ## At the top, I use the solution of the unconstrainted, i.e. pw = 1 (I could also do reflecting boundary but less elegant)
     pt = - ((((r + ψ * (ρ - r)) * pw^(1 - ψ) - ψ * ρ) / (ψ - 1) + μ - γ * σ^2 / 2) * p + ((r - μ + γ * σ^2) * w + 1) * pw + σ^2 * w^2 / 2  * (pww - γ * pw^2 / p))
-    return (; pt)
+    return (; pt), (; c, μw)
 end
 
-# ## Solving it
-#
-# The state ``w`` runs from the borrowing limit to a large upper bound on a grid that is denser
-# near the constraint. The initial guess ``p = 1 + w`` reflects total wealth as financial plus
-# one unit of human wealth, and the boundary condition ``p'(w) = 1`` pins the marginal value of
-# wealth at both ends.
+# With the equation, grid, and guess in hand, `pdesolve` solves the stationary system, imposing
+# the boundary condition ``p'(w) = 1`` — which pins the marginal value of wealth — at both ends:
 
-m = WangWangYangModel()
-stategrid = (; w = range(m.wmin^(1/2), m.wmax^(1/2), length = 100).^2)
-yend = (; p = 1 .+ stategrid[:w])
 result = pdesolve(m, stategrid, yend, bc = (; pw = (1.0, 1.0)))
 
 # ## The solution
 #
-# The scaled value ``p(w)`` is increasing and concave in the wealth-to-income ratio:
+# The consumption–income ratio and the saving rate, over the low-wealth region:
 
 ws = stategrid[:w]
-plot(ws, result.zero[:p]; xlabel = "wealth-income ratio w", ylabel = "scaled value p(w)", legend = false)
+idx = 1:div(length(ws), 3)          # left third of the grid, where the curvature is
+p1 = plot(ws[idx], result.optional[:c][idx]; xlabel = "wealth-income ratio w", ylabel = "consumption c", legend = false)
+p2 = plot(ws[idx], result.optional[:μw][idx]; xlabel = "wealth-income ratio w", ylabel = "saving μw", legend = false)
+hline!(p2, [0.0]; color = :gray, linestyle = :dash)
+plot(p1, p2; layout = (1, 2), size = (800, 300))
 
-# ``p(w)`` measures total wealth — financial plus human — per unit of income. Its intercept
-# ``p(0)`` is the value of human wealth (the capitalized income stream) for a household stuck at
-# the borrowing constraint, and its slope approaches one as financial wealth grows and human
-# wealth becomes negligible in comparison. The concavity near ``w = 0`` reflects the shadow value
-# of the borrowing constraint: an extra unit of wealth is worth most to a constrained household,
-# which is exactly where the precautionary motive and the marginal propensity to consume are
-# highest.
+# Consumption (left) is increasing and concave in the wealth-to-income ratio, steepest near the
+# borrowing constraint where the marginal propensity to consume is highest. The saving rate (right)
+# is largest for constrained, low-wealth households and declines as wealth rises toward its target —
+# the shadow value of the borrowing constraint fading as financial wealth accumulates.

--- a/examples/corporate_finance/bolton_chen_wang.jl
+++ b/examples/corporate_finance/bolton_chen_wang.jl
@@ -15,20 +15,45 @@
 # ``\gamma`` and fixed cost ``\phi``.
 
 # ## The model
+#
+# The parameters:
 
 using EconPDEs, NLsolve, Plots
 
 Base.@kwdef struct BoltonChenWangModel
-  r::Float64 = 0.06
-  δ::Float64 = 0.10
-  A::Float64 = 0.18
-  σ::Float64 = 0.09
-  θ::Float64 = 1.5
-  λ::Float64 = 0.01
-  l::Float64 = 0.9
-  γ::Float64 = 0.06
-  ϕ::Float64 = 0.01
+  r::Float64 = 0.06       # risk-free rate
+  δ::Float64 = 0.10       # depreciation rate of capital
+  A::Float64 = 0.18       # productivity (expected profitability per unit capital)
+  σ::Float64 = 0.09       # cash-flow (capital) volatility
+  θ::Float64 = 1.5        # investment adjustment-cost parameter
+  λ::Float64 = 0.01       # carrying cost of holding cash
+  l::Float64 = 0.9        # liquidation value of capital
+  γ::Float64 = 0.06       # marginal (proportional) cost of external finance
+  ϕ::Float64 = 0.01       # fixed cost of external finance
 end
+
+# ## The state space
+#
+# We build the grid and the initial guess first, because they fix the names used everywhere else.
+# The grid is a `NamedTuple` whose key is the state variable (`w`, the cash–capital ratio); the
+# guess is a `NamedTuple` whose key is the unknown function (`v`), holding one starting value at
+# each grid point (firm value is initialized to the cash ratio ``w`` itself). These names are what
+# reappear inside the equation below — e.g. `vw_up` will be the forward finite difference of `v`
+# in `w`.
+
+m = BoltonChenWangModel()
+stategrid = (; w = range(0.0, 0.3, length = 100))
+yend = (; v = stategrid[:w])
+
+# ## The equation
+#
+# We now write the function encoding the HJB equation. Following the package convention, it takes
+# the current `state` (a grid point) and `u` — the local bundle holding the unknown and its
+# finite-difference derivatives there (`v`, `vw_up`, `vw_down`, `vww`) — and returns the time
+# derivative `vt`.
+#
+# The cash drift ``\mu_w`` can point either way, so the marginal value of cash is upwinded:
+# forward (`vw_up`) where the drift is positive, backward (`vw_down`) where it is negative.
 
 function (m::BoltonChenWangModel)(state::NamedTuple, u::NamedTuple)
   (; r, δ, A, σ, θ, λ, l, γ, ϕ) = m
@@ -48,13 +73,8 @@ function (m::BoltonChenWangModel)(state::NamedTuple, u::NamedTuple)
   return (; vt), (; v, vw, vww, w)
 end
 
-# ## Solving it
-#
 # We first solve the HJB with guessed slopes for the marginal value of cash at the two boundaries.
 
-m = BoltonChenWangModel()
-stategrid = (; w = range(0.0, 0.3, length = 100))
-yend = (; v = stategrid[:w])
 result = pdesolve(m, stategrid, yend; bc = (; vw = (1.5, 1.0)))
 
 # The guessed slopes are only a starting point. We then use `NLsolve` to find the boundary slopes

--- a/examples/corporate_finance/leland.jl
+++ b/examples/corporate_finance/leland.jl
@@ -16,16 +16,37 @@
 # threshold ``\delta^*``.
 
 # ## The model
+#
+# The parameters live in a `struct`:
 
 using EconPDEs, Plots
 
 Base.@kwdef struct LelandModel
-    r::Float64 = 0.02
-    μ::Float64 = 0.0
-    σ::Float64 = 0.1
+    r::Float64 = 0.02    # risk-free rate
+    μ::Float64 = 0.0     # drift of cash flow (EBIT growth)
+    σ::Float64 = 0.1     # volatility of cash flow
     C::Float64 = 0.05    # coupon rate
     τ::Float64 = 0.2     # tax rate
 end
+
+# ## The state space
+#
+# We build the grid and the initial guess first, because they fix the names used everywhere
+# else. The grid is a `NamedTuple` whose key is the state variable (`δ`, the cash flow); the
+# guess is a `NamedTuple` whose key is the unknown function (`E`, equity value), holding one
+# starting value at each grid point. These names reappear inside the equation below — e.g.
+# `Eδ_up` will be the forward finite difference of `E` in `δ`. We start the guess from the value
+# of the cash-flow claim net of the after-tax coupon, floored at zero.
+
+m = LelandModel()
+stategrid = (; δ = range(0, 0.2, step = 0.005))
+yend = (; E = max.(stategrid[:δ] ./ (m.r - m.μ) .- (1 .- m.τ) .* m.C ./ m.r, 0.0))
+
+# ## The equation
+#
+# We now write the function encoding the HJB equation. Following the package convention, it
+# takes the current `state` (a grid point) and `u` (each unknown together with its
+# finite-difference derivatives there) and returns the time derivative of each unknown.
 
 function (m::LelandModel)(state::NamedTuple, u::NamedTuple)
     (; r, μ, σ, C, τ) = m
@@ -38,15 +59,10 @@ function (m::LelandModel)(state::NamedTuple, u::NamedTuple)
     return (; Et)
 end
 
-# ## Solving it
-#
 # The stopping (default) region is imposed with the lower bound `y̲ = 0`: equity can never be
-# worth less than zero. We also pin the slope at the top boundary to that of a debt-free
-# claim, ``1/(r-\mu)``.
+# worth less than zero. We also pin the slope at the top boundary to that of a debt-free claim,
+# ``1/(r-\mu)``. With these in hand, `pdesolve` solves the variational inequality:
 
-m = LelandModel()
-stategrid = (; δ = range(0, 0.2, step = 0.005))
-yend = (; E = max.(stategrid[:δ] ./ (m.r - m.μ) .- (1 .- m.τ) .* m.C ./ m.r, 0.0))
 y̲ = zeros(length(stategrid[:δ]))
 bc = (; Eδ = (0.0, 1 / (m.r - m.μ)))
 result = pdesolve(m, stategrid, yend; y̲ = y̲, bc = bc, reformulation = :smooth)

--- a/examples/neoclassical_growth.jl
+++ b/examples/neoclassical_growth.jl
@@ -18,6 +18,8 @@
 # with first-order condition ``c = v'(k)^{-1/\gamma}``.
 
 # ## The model
+#
+# The parameters live in a `struct`:
 
 using EconPDEs, Plots
 
@@ -29,10 +31,35 @@ Base.@kwdef struct NeoclassicalGrowthModel
     γ::Float64 = 2.0     # relative risk aversion
 end
 
+# ## The state space
+#
+# We build the grid and the initial guess first, because they fix the names used everywhere
+# else. The grid is a `NamedTuple` whose key is the state variable (`k`); the guess is a
+# `NamedTuple` whose key is the unknown function (`v`), holding one starting value at each grid
+# point. These names are what reappear inside the equation below — e.g. `vk_up` will be the
+# forward finite difference of `v` in `k`.
+#
+# We center the grid on the closed-form steady state ``\bar k`` (where
+# ``\alpha A \bar k^{\alpha-1} = \rho + \delta``) and start from the value of consuming gross
+# output forever.
+
+m = NeoclassicalGrowthModel()
+(; A, α, δ, ρ, γ) = m
+k̄ = (α * A / (ρ + δ))^(1 / (1 - α))
+stategrid = (; k = range(0.1 * k̄, 5 * k̄, length = 1000))
+yend = (; v = [(A * k^α)^(1 - γ) / (1 - γ) / ρ for k in stategrid[:k]])
+
+# ## The equation
+#
+# We now write the function encoding the HJB equation. Following the package convention, it
+# takes the current `state` (a grid point) and `u` — the local bundle holding each unknown and
+# its finite-difference derivatives there (here `v`, `vk_up`, `vk_down`) — and returns the time
+# derivative `vt` of each unknown.
+#
 # The capital drift ``\dot k`` can point either way, so the first derivative is *upwinded*:
 # forward (`vk_up`) where the implied drift is positive, backward (`vk_down`) where it is
-# negative, and the consumption that sets the drift to zero at the steady state in between.
-# We return a second `NamedTuple` to save consumption `c` and the drift `μk` on the grid.
+# negative, and the consumption that sets the drift to zero at the steady state in between. A
+# second `NamedTuple` saves consumption `c` and the drift `μk` on the grid.
 
 function (m::NeoclassicalGrowthModel)(state::NamedTuple, u::NamedTuple)
     (; A, α, δ, ρ, γ) = m
@@ -57,17 +84,8 @@ function (m::NeoclassicalGrowthModel)(state::NamedTuple, u::NamedTuple)
     return (; vt), (; c, μk)
 end
 
-# ## Solving it
-#
-# Put capital on a grid around the closed-form steady state ``\bar k`` defined by
-# ``\alpha A \bar k^{\alpha-1} = \rho + \delta``, and start from the value of consuming
-# gross output forever.
+# With the equation, grid, and guess in hand, `pdesolve` solves the stationary system:
 
-m = NeoclassicalGrowthModel()
-(; A, α, δ, ρ, γ) = m
-k̄ = (α * A / (ρ + δ))^(1 / (1 - α))
-stategrid = (; k = range(0.1 * k̄, 5 * k̄, length = 1000))
-yend = (; v = [(A * k^α)^(1 - γ) / (1 - γ) / ρ for k in stategrid[:k]])
 result = pdesolve(m, stategrid, yend)
 
 # ## The solution

--- a/examples/runbenchmark.jl
+++ b/examples/runbenchmark.jl
@@ -6,17 +6,17 @@ using EconPDEs
 const EXAMPLES_DIR = joinpath(pkgdir(EconPDEs), "examples")
 
 # PDE with 1 state variable
-include(joinpath(EXAMPLES_DIR, "finance", "campbell_cochrane.jl"))
+include(joinpath(EXAMPLES_DIR, "asset_pricing", "campbell_cochrane.jl"))
 @time pdesolve(m, stategrid, yend)
 
 # PDE with 2 state variables
-include(joinpath(EXAMPLES_DIR, "finance", "bansal_yaron.jl"))
+include(joinpath(EXAMPLES_DIR, "asset_pricing", "bansal_yaron.jl"))
 @time pdesolve(m, stategrid, yend)
 
 # System of 4 PDEs with 1 state variable
-include(joinpath(EXAMPLES_DIR, "finance", "garleanu_panageas.jl"))
+include(joinpath(EXAMPLES_DIR, "asset_pricing", "garleanu_panageas.jl"))
 @time pdesolve(m, stategrid, yend)
 
 # System of 3 PDEs with 2 state variables
-include(joinpath(EXAMPLES_DIR, "finance", "di_tella.jl"))
+include(joinpath(EXAMPLES_DIR, "asset_pricing", "di_tella.jl"))
 @time pdesolve(m, stategrid, yend)


### PR DESCRIPTION
Follow-up to #42, reorganizing the example gallery and standardizing every example page.

- Group examples into `consumption_saving`, `asset_pricing`, and `corporate_finance` folders, with neoclassical growth as the standalone entry point.
- Give every example page a four-section flow (model → state space → equation → solution) and a per-parameter comment on each struct (`r` standardized to "risk-free rate").
- Standardize structs on `Base.@kwdef` and use NamedTuple grids and guesses throughout.
- For every consumption–saving example, plot consumption and the saving drift, zoomed to the low-wealth region where the curvature is visible.
- Set default plot margins so axis labels are not clipped.