### PR TITLE
Refine solution workflow and saved outputs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "EconPDEs"
 uuid = "a3315474-fad9-5060-8696-cee5f38a87b7"
-version = "1.5.0"
+version = "1.6.0"
 
 [deps]
 FiniteDiff = "6a86dc24-6348-571c-b903-95158fe2bd41"

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ guess = (; v = zeros(length(grid.a), length(grid.y)))
 
 Inside your equation, `state` is the current grid point and `u` contains the value and derivative stencils. If the unknown is `v` and the state is `k`, then `u.v` is the local value and `u.vk_up`, `u.vk_down`, and `u.vkk` are finite-difference derivatives.
 
-Return one time derivative per unknown, named by appending `t`: `(; vt)` for unknown `v`, or `(; vt, wt)` for unknowns `v` and `w`. Return a second `NamedTuple` to save policies, drifts, prices, or other objects on the grid.
+Return one time derivative per unknown, named by appending `t`: `(; vt)` for unknown `v`, or `(; vt, wt)` for unknowns `v` and `w`. Return a second `NamedTuple` to save policies, drifts, prices, or other objects on the grid; they are available as `result.saved`.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ The manual gives the details:
 - [Getting started](https://www.matthieugomez.com/EconPDEs.jl/dev/getting_started/)
 - [Solving models](https://www.matthieugomez.com/EconPDEs.jl/dev/solving/)
 - [Why EconPDEs](https://www.matthieugomez.com/EconPDEs.jl/dev/design/)
-- [InfinitesimalGenerators](https://www.matthieugomez.com/EconPDEs.jl/dev/infinitesimal_generators/)
+- [InfinitesimalGenerators](https://www.matthieugomez.com/EconPDEs.jl/dev/infinitesimal_generators/) — using the companion package [InfinitesimalGenerators.jl](https://github.com/matthieugomez/InfinitesimalGenerators.jl) for stationary distributions and expectations after solving
 
 The documentation also includes a gallery of runnable examples:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build status](https://github.com/matthieugomez/EconPDEs.jl/workflows/CI/badge.svg)](https://github.com/matthieugomez/EconPDEs.jl/actions)
 [![Coverage Status](http://codecov.io/github/matthieugomez/EconPDEs.jl/coverage.svg?branch=main)](http://codecov.io/github/matthieugomez/EconPDEs.jl/?branch=main)
-[![Docs](https://img.shields.io/badge/docs-dev-blue.svg)](https://matthieugomez.github.io/EconPDEs.jl/dev)
+[![Docs](https://img.shields.io/badge/docs-dev-blue.svg)](https://www.matthieugomez.com/EconPDEs.jl/dev/)
 
 # EconPDEs.jl
 
@@ -89,10 +89,10 @@ Return one time derivative per unknown, named by appending `t`: `(; vt)` for unk
 
 The manual gives the details:
 
-- [Getting started](https://matthieugomez.github.io/EconPDEs.jl/dev/getting_started/)
-- [Solving models](https://matthieugomez.github.io/EconPDEs.jl/dev/solving/)
-- [Why EconPDEs](https://matthieugomez.github.io/EconPDEs.jl/dev/design/)
-- [InfinitesimalGenerators](https://matthieugomez.github.io/EconPDEs.jl/dev/infinitesimal_generators/)
+- [Getting started](https://www.matthieugomez.com/EconPDEs.jl/dev/getting_started/)
+- [Solving models](https://www.matthieugomez.com/EconPDEs.jl/dev/solving/)
+- [Why EconPDEs](https://www.matthieugomez.com/EconPDEs.jl/dev/design/)
+- [InfinitesimalGenerators](https://www.matthieugomez.com/EconPDEs.jl/dev/infinitesimal_generators/)
 
 The documentation also includes a gallery of runnable examples:
 
@@ -105,7 +105,7 @@ The source scripts live in [`examples/`](examples).
 ## Numerical Details
 
 For the finite-difference discretization and the pseudo-transient Newton scheme behind
-`pdesolve`, see [Solving models](https://matthieugomez.github.io/EconPDEs.jl/dev/solving/#Solver-and-troubleshooting).
+`pdesolve`, see [Solving models](https://www.matthieugomez.com/EconPDEs.jl/dev/solving/#Solver-and-troubleshooting).
 
 ## Citation
 

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -7,3 +7,6 @@ Literate = "98b081ad-f1c9-55d3-8b20-4c87d4299306"
 NLsolve = "2774e3e8-f4cf-5e23-947b-6d7e65073b56"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Roots = "f2b01f46-fcfa-551c-844a-d8ac1e96c665"
+
+[compat]
+InfinitesimalGenerators = "3"

--- a/docs/src/design.md
+++ b/docs/src/design.md
@@ -11,7 +11,7 @@ that general PDE interfaces often do not make convenient.
 
 | Economic HJBs need | What this means in practice |
 | --- | --- |
-| Infinitesimal generators | The operator describes how the state moves locally: drift times the first derivative plus volatility squared times the second derivative. |
+| Infinitesimal generators | The operator describes how the state moves locally: drift times the first derivative plus volatility squared times the second derivative. The companion package [InfinitesimalGenerators.jl](https://github.com/matthieugomez/InfinitesimalGenerators.jl) works with these operators directly; see [InfinitesimalGenerators](infinitesimal_generators.md). |
 | Policies inside the equation | Drift, diffusion, controls, and nonlinear terms can depend on the current guess for the value function. You write these terms directly, in the same place as the policy rule. |
 | Upwinding by drift sign | The first derivative must be taken from the right side. If the drift changes during the solve, the stencil changes too. See [Getting started](getting_started.md#Upwinding). |
 | Economic boundaries | Borrowing limits, reflecting states, and degenerate diffusions are not just Dirichlet or periodic boundary conditions. See [Solving models](solving.md#Boundary-conditions). |

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -85,20 +85,9 @@ end
 ```
 
 The function returns one *time derivative* per unknown, named `Symbol(unknown, :t)` — here
-`vt`. The sign convention matters:
-
-!!! note "Why `vt = -(...)`?"
-    `pdesolve` treats the stationary equation as the long-run limit of the time-dependent
-    equation ``\partial_t v = \text{vt}`` and integrates this *false transient* until it
-    stops moving. For an HJB written as
-    ``\rho v = u(c) + v'(k)\mu_k``, the time-dependent version is the backward equation
-    ``\rho v = u(c) + v'(k)\mu_k + \partial_t v``, so the PDE function must return
-    ``\text{vt} = -\left(u(c) + v'(k)\mu_k - \rho v\right)``.
-    With this sign, the false transient is stable — each pseudo-time step is a contraction
-    and the iteration converges to the stationary solution. Flip the sign and the iteration
-    runs *away* from the solution: if a model diverges immediately, this sign is the first
-    thing to check. See [Solving models](solving.md#Solver-and-troubleshooting) for how
-    the pseudo-transient scheme works.
+`vt`. For a stationary equation written as `0 = RHS - ρv`, return the negative residual:
+`vt = -(RHS - ρv)`. The full sign convention is explained
+[below](#The-return-value:-one-time-derivative-per-unknown).
 
 ### Solving
 
@@ -111,10 +100,11 @@ result.residual_norm       # should be ≈ 0
 `pdesolve` returns an [`EconPDEResult`](api.md) with the solved unknowns in `result.zero`,
 indexed by name.
 
-## Saving policies and other outputs
+## Exploring the solution
 
-Objects computed inside the PDE function — the optimal policy, a drift, an interest rate —
-can be stored on the grid by returning a *second* `NamedTuple`:
+`result.zero` holds the solved unknowns. Objects computed inside the PDE function — the
+optimal policy, a drift, an interest rate — can also be stored on the grid by returning a
+*second* `NamedTuple`:
 
 ```julia
 function hjb(state::NamedTuple, u::NamedTuple)
@@ -127,12 +117,33 @@ result = pdesolve(hjb, stategrid, guess)
 consumption = result.optional[:c]     # same shape as the grid
 ```
 
-Each saved object has the same shape as the state grid, so it plots directly against it:
+Each saved object has the same shape as the state grid, so it plots directly against it.
+The saved drift is often the most useful diagnostic: it shows where the state moves and
+where it stops.
 
 ```julia
 using Plots
 plot(stategrid[:k], result.optional[:c]; xlabel = "k", ylabel = "consumption")
+plot(stategrid[:k], result.optional[:μk]; xlabel = "k", ylabel = "capital drift")
 ```
+
+Saved drifts are also the bridge to stationary distributions. Once the HJB is solved, the
+policy-implied law of motion is known. For a one-state model with drift `μk` and no
+diffusion:
+
+```julia
+using InfinitesimalGenerators
+
+kgrid = stategrid[:k]
+μk = result.optional[:μk]
+K = DiffusionProcess(kgrid, μk, zeros(length(kgrid)))
+stationary = stationary_distribution(K)
+```
+
+In stochastic models, pass the solved volatility as the third argument to
+`DiffusionProcess`. With discrete states, build one process per state and combine them with
+`SwitchingProcess`; see [InfinitesimalGenerators](infinitesimal_generators.md) for a full
+consumption-saving example.
 
 ## Model conventions
 

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -114,7 +114,7 @@ function hjb(state::NamedTuple, u::NamedTuple)
 end
 
 result = pdesolve(hjb, stategrid, guess)
-consumption = result.optional[:c]     # same shape as the grid
+consumption = result.saved[:c]     # same shape as the grid
 ```
 
 Each saved object has the same shape as the state grid, so it plots directly against it.
@@ -123,8 +123,8 @@ where it stops.
 
 ```julia
 using Plots
-plot(stategrid[:k], result.optional[:c]; xlabel = "k", ylabel = "consumption")
-plot(stategrid[:k], result.optional[:μk]; xlabel = "k", ylabel = "capital drift")
+plot(stategrid[:k], result.saved[:c]; xlabel = "k", ylabel = "consumption")
+plot(stategrid[:k], result.saved[:μk]; xlabel = "k", ylabel = "capital drift")
 ```
 
 Saved drifts are also the bridge to stationary distributions. Once the HJB is solved, the
@@ -135,7 +135,7 @@ diffusion:
 using InfinitesimalGenerators
 
 kgrid = stategrid[:k]
-μk = result.optional[:μk]
+μk = result.saved[:μk]
 K = DiffusionProcess(kgrid, μk, zeros(length(kgrid)))
 stationary = stationary_distribution(K)
 ```
@@ -242,7 +242,7 @@ return (; vt), (; c, μa, r)
 ```
 
 Each object in the second `NamedTuple` is evaluated at every grid point and stored as an
-array with the same shape as the grid, available in `result.optional`.
+array with the same shape as the grid, available in `result.saved`.
 
 ### The result
 
@@ -251,10 +251,11 @@ array with the same shape as the grid, available in `result.optional`.
 - `zero`: the solved unknowns, indexed by name (`result.zero[:v]`);
 - `residual_norm`: the norm of the residual at the solution — check it is small before
   using the output;
-- `optional`: the saved objects, together with the solved unknowns for convenience.
+- `saved`: the saved objects, together with the solved unknowns for convenience.
 
 For a time-dependent problem, `zero` is instead a vector of solutions, one per time point
 (`result.zero[i][:v]`), and `residual_norm` a vector of residual norms.
+For older code, `result.optional` remains an alias for `result.saved`.
 
 ## Upwinding
 

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -280,6 +280,13 @@ collapses (see [Solving models](solving.md#Solver-and-troubleshooting)). Central
 differences for the *second* derivative are always fine (their weights are automatically
 positive), which is why `vkk` comes in only one flavor.
 
+Monotonicity also has a probabilistic reading: a monotone scheme is exactly one whose
+discretized operator is a valid Markov generator, with non-negative jump rates to
+neighboring grid points. That is the condition under which
+[InfinitesimalGenerators.jl](https://matthieugomez.github.io/InfinitesimalGenerators.jl/dev/univariate/)
+turns the same discretization into a Markov chain — and why an upwinded solution hands off
+exactly to its [distributions and expectations](infinitesimal_generators.md).
+
 ### Pattern 1: exogenous drift
 
 When the drift of a state does not depend on the derivative you are choosing, upwinding is

--- a/docs/src/infinitesimal_generators.md
+++ b/docs/src/infinitesimal_generators.md
@@ -4,148 +4,263 @@
 [`InfinitesimalGenerators.jl`](https://github.com/matthieugomez/InfinitesimalGenerators.jl)
 are complementary.
 
-`InfinitesimalGenerators.jl` is the right tool when the process is already known. It builds
-finite-difference derivatives, Markov-process generators, stationary distributions, and
-linear Feynman-Kac objects. `EconPDEs.jl` is the better fit when the equation is nonlinear:
-policies, prices, drifts, volatilities, or occasionally the upwind direction itself are
-functions of the unknown solution. In that case `pdesolve` handles the local nonlinear
-equation, the generated derivative names, the sparse residual, pseudo-transient Newton, and
-optional outputs.
+`EconPDEs.jl` solves the nonlinear problem: policies, prices, drifts, volatilities, or
+occasionally the upwind direction itself are functions of the unknown solution, and
+`pdesolve` handles the local nonlinear equation, the generated derivative names, the sparse
+residual, and pseudo-transient Newton. Once that problem is solved, the model reduces to a
+*known* Markov process — the states follow the policy-implied law of motion — and that is
+where `InfinitesimalGenerators.jl` takes over: it turns the solved law of motion into a
+generator matrix and computes stationary distributions, expectations, and tail indices.
 
-Two common workflows use both packages.
+This page extends the short workflow in
+[Exploring the solution](getting_started.md#Exploring-the-solution). It walks through the
+full version on the
+[consumption–saving model with two income states](examples/consumption_saving/consumption_saving_two_income.md):
+solve the coupled HJB with `pdesolve`, build the solved Markov process, compute the
+stationary wealth distribution, and check the solution with Feynman–Kac.
 
-## Stationary distributions after `pdesolve`
+## From `pdesolve` to a Markov process
 
-Solve the nonlinear HJB with `EconPDEs.jl`, return the controlled drift and volatility as
-optional outputs, then pass the solved Markov process to `InfinitesimalGenerators.jl`.
-
-For the Wang-Wang-Yang example, `pdesolve` returns the policy-implied drift `μw`.
-Here we use a short grid so the block can run as part of the documentation build:
+In the two-income model, a household saves in a riskless asset ``a`` while its labor income
+switches between ``y_l`` and ``y_h`` as a two-state Poisson process. The model definition is
+the one from the [example page](examples/consumption_saving/consumption_saving_two_income.md);
+the only thing that matters here is that the equation returns the policy-implied asset
+drifts `μla` and `μha` as
+[optional outputs](getting_started.md#Exploring-the-solution), so that `pdesolve` saves
+them on the grid:
 
 ```@example infinitesimal_generators
 using EconPDEs
 using InfinitesimalGenerators
 
-Base.@kwdef struct WangWangYangModel # hide
-    μ::Float64 = 0.015 # hide
-    σ::Float64 = 0.1 # hide
-    r::Float64 = 0.035 # hide
+Base.@kwdef mutable struct AchdouHanLasryLionsMollModel_TwoStates # hide
+    yl::Float64 = 0.5 # hide
+    yh::Float64 = 1.5 # hide
+    λlh::Float64 = 0.2 # hide
+    λhl::Float64 = 0.2 # hide
+    r::Float64 = 0.03 # hide
     ρ::Float64 = 0.04 # hide
-    γ::Float64 = 3.0 # hide
-    ψ::Float64 = 1.1 # hide
-    wmin::Float64 = 0.0 # hide
-    wmax::Float64 = 1000.0 # hide
+    γ::Float64 = 2.0 # hide
+    amin::Float64 = -yl / r # hide
+    amax::Float64 = 50.0 # hide
 end # hide
-function (m::WangWangYangModel)(state::NamedTuple, u::NamedTuple) # hide
-    (; μ, σ, r, ρ, γ, ψ, wmin) = m # hide
-    (; w) = state # hide
-    (; p, pw_up, pw_down, pww) = u # hide
-    cmax = 100.0 * (1 + max((r - μ + σ^2) * w, 0.0)) # hide
-    c_up = pw_up > 0 ? min((r + ψ * (ρ - r)) * p * pw_up^(-ψ), cmax) : cmax # hide
-    μw_up = (r - μ + σ^2) * w + 1 - c_up # hide
-    if μw_up >= 0 # hide
-        pw = pw_up # hide
-        c = c_up # hide
-        μw = μw_up # hide
+function (m::AchdouHanLasryLionsMollModel_TwoStates)(state::NamedTuple, u::NamedTuple) # hide
+    (; yl, yh, λlh, λhl, r, ρ, γ, amin, amax) = m # hide
+    (; a) = state # hide
+    (; vl, vla_up, vla_down, vh, vha_up, vha_down) = u # hide
+    clmax = 100.0 * (yl + r * max(a, 0.0)) # hide
+    chmax = 100.0 * (yh + r * max(a, 0.0)) # hide
+    cl_up = vla_up > 0 ? min(vla_up^(-1 / γ), clmax) : clmax # hide
+    μla_up = yl + r * a - cl_up # hide
+    if μla_up >= 0.0 # hide
+        vla, cl, μla = vla_up, cl_up, μla_up # hide
     else # hide
-        c_down = pw_down > 0 ? min((r + ψ * (ρ - r)) * p * pw_down^(-ψ), cmax) : cmax # hide
-        μw_down = (r - μ + σ^2) * w + 1 - c_down # hide
-        if (μw_down <= 0) && (w > wmin) # hide
-            pw = pw_down # hide
-            c = c_down # hide
-            μw = μw_down # hide
+        cl_down = vla_down > 0 ? min(vla_down^(-1 / γ), clmax) : clmax # hide
+        μla_down = yl + r * a - cl_down # hide
+        if μla_down <= 0.0 && a > amin # hide
+            vla, cl, μla = vla_down, cl_down, μla_down # hide
         else # hide
-            μw = 0.0 # hide
-            c = 1 + (r - μ + σ^2) * w # hide
-            pw = (c / ((r + ψ * (ρ - r)) * p))^(-1 / ψ) # hide
+            cl = yl + r * a # hide
+            μla = 0.0 # hide
+            vla = cl^(-γ) # hide
         end # hide
     end # hide
-    pt = -((((r + ψ * (ρ - r)) * pw^(1 - ψ) - ψ * ρ) / (ψ - 1) + μ - γ * σ^2 / 2) * p + ((r - μ + γ * σ^2) * w + 1) * pw + σ^2 * w^2 / 2 * (pww - γ * pw^2 / p)) # hide
-    return (; pt), (; c, μw) # hide
+    vlt = -(cl^(1 - γ) / (1 - γ) + μla * vla + λlh * (vh - vl) - ρ * vl) # hide
+    ch_up = vha_up > 0 ? min(vha_up^(-1 / γ), chmax) : chmax # hide
+    μha_up = yh + r * a - ch_up # hide
+    if μha_up >= 0.0 # hide
+        vha, ch, μha = vha_up, ch_up, μha_up # hide
+    else # hide
+        ch_down = vha_down > 0 ? min(vha_down^(-1 / γ), chmax) : chmax # hide
+        μha_down = yh + r * a - ch_down # hide
+        if μha_down <= 0.0 && a > amin # hide
+            vha, ch, μha = vha_down, ch_down, μha_down # hide
+        else # hide
+            ch = yh + r * a # hide
+            μha = 0.0 # hide
+            vha = ch^(-γ) # hide
+        end # hide
+    end # hide
+    vht = -(ch^(1 - γ) / (1 - γ) + μha * vha + λhl * (vl - vh) - ρ * vh) # hide
+    return (; vlt, vht), (; cl, ch, μla, μha) # hide
 end # hide
 
-m = WangWangYangModel()
-stategrid = (; w = range(m.wmin^(1 / 2), m.wmax^(1 / 2), length = 50).^2)
-yend = (; p = 1 .+ stategrid[:w])
+m = AchdouHanLasryLionsMollModel_TwoStates()
+m.amin += 0.001
+stategrid = (; a = m.amin .+ range(0, (m.amax - m.amin)^(1 / 2), length = 200) .^ 2)
+yend = (;
+    vl = (m.ρ ./ m.γ .+ (1 .- 1 / m.γ) .* m.r)^(-m.γ) .* (stategrid[:a] .+ m.yl ./ m.r) .^ (1 - m.γ) ./ (1 - m.γ),
+    vh = (m.ρ ./ m.γ .+ (1 .- m.γ) .* m.r)^(-m.γ) .* (stategrid[:a] .+ m.yh ./ m.r) .^ (1 - m.γ) ./ (1 - m.γ),
+)
 
-result = pdesolve(m, stategrid, yend; bc = (; pw = (1.0, 1.0)), verbose = false)
+result = pdesolve(m, stategrid, yend; verbose = false)
+@assert result.residual_norm <= 1e-6 # hide
 
-ws = stategrid[:w]
-μw = result.optional[:μw]
-σw = m.σ .* ws
+as = stategrid[:a]
+μla = result.optional[:μla]
+μha = result.optional[:μha]
+nothing # hide
+```
 
-X = DiffusionProcess(ws, μw, σw)
-stationary = stationary_distribution(X)
+The solved model is a Markov process on `(a, y)`: income is a two-state Markov chain, and
+within each income state assets drift deterministically at the policy-implied rate. This is
+exactly what `SwitchingProcess` represents — a `MarkovChain` plus one continuous process per
+income state, here two `DiffusionProcess`es with zero volatility:
 
-@assert result.residual_norm <= 1e-5 # hide
-@assert length(stationary) == length(ws) # hide
-@assert abs(sum(stationary) - 1) <= sqrt(eps()) # hide
+```@example infinitesimal_generators
+Z = MarkovChain([m.yl, m.yh], [-m.λlh m.λlh; m.λhl -m.λhl])
+Xl = DiffusionProcess(as, μla, zeros(length(as)))
+Xh = DiffusionProcess(as, μha, zeros(length(as)))
+X = SwitchingProcess(Z, [Xl, Xh])
+size(X)
+```
+
+`generator(X)` is the transition-rate matrix of the discretized process, built with the same
+[upwind convention](getting_started.md#Upwinding) `pdesolve` uses (forward differences where
+the drift is positive, backward where it is negative, with the same default
+[reflecting boundaries](solving.md#Boundary-conditions)). That consistency matters below.
+
+## Stationary distribution
+
+The one-state version of this step is shown in
+[Exploring the solution](getting_started.md#Exploring-the-solution). Here the same idea is
+applied to the switching process.
+
+The stationary distribution solves the Kolmogorov forward equation — the left null vector of
+the generator. `stationary_distribution` returns the probability mass at each grid point,
+shaped like the state space:
+
+```@example infinitesimal_generators
+g = stationary_distribution(X)
+size(g)
+```
+
+Column 1 is the distribution of assets among low-income households, column 2 among
+high-income households. Dividing the masses by the cell widths gives a density:
+
+```@example infinitesimal_generators
+using Plots
+
+Δa = (as[[2:end; end]] .- as[[1; 1:(end - 1)]]) ./ 2
+idx = as .<= 10
+plot(as[idx], (g ./ Δa)[idx, :];
+    label = ["low income" "high income"], xlabel = "assets a", ylabel = "stationary density")
+```
+
+Low-income households dissave toward the borrowing limit; high-income households accumulate.
+Any moment of the stationary distribution is now a weighted sum:
+
+```@example infinitesimal_generators
+cl = result.optional[:cl]
+ch = result.optional[:ch]
+mean_assets = sum(g .* as)
+share_borrowers = sum(g[as .< 0, :])
+aggregate_consumption = sum(g .* [cl ch])
+aggregate_income = sum(g .* [fill(m.yl, length(as)) fill(m.yh, length(as))]) + m.r * mean_assets
+(; mean_assets, share_borrowers, aggregate_consumption, aggregate_income)
+```
+
+Aggregate consumption equals aggregate income to machine precision: in the stationary
+distribution, average saving ``E[y + ra - c]`` is zero. Getting this identity for free —
+rather than up to discretization error — is a consequence of computing the distribution from
+the same discretized generator that solved the HJB.
+
+```@example infinitesimal_generators
+@assert abs(sum(g) - 1) <= sqrt(eps()) # hide
+@assert abs(aggregate_consumption - aggregate_income) <= 1e-6 # hide
+nothing # hide
+```
+
+## Checking the solution with Feynman–Kac
+
+`feynman_kac` computes conditional expectations under the solved process. A natural check:
+the expected discounted utility from following the solved policy,
+``E[\int_0^\infty e^{-\rho t} u(c_t) \, dt \mid a_0, y_0]``, must reproduce the value
+function itself.
+
+```@example infinitesimal_generators
+uc = [cl ch] .^ (1 - m.γ) ./ (1 - m.γ)
+ts = range(0, 600, step = 2)
+V = feynman_kac(X, ts; f = uc, v = m.ρ .* ones(size(X)...))
+maximum(abs, V[:, :, 1] .- [result.zero[:vl] result.zero[:vh]])
+```
+
+The two agree to solver tolerance, not just to discretization error. This is again because
+the two packages share the upwind convention: at convergence, the discretized HJB solved by
+`pdesolve` is exactly ``\rho v = u(c) + \mathbb{T} v`` where ``\mathbb{T}`` is
+`generator(X)`. If the recovered `V` were far from `result.zero`, it would flag an
+inconsistency — for example a drift saved in `optional` that does not match the upwind
+branch actually used in the equation.
+
+```@example infinitesimal_generators
+@assert maximum(abs, V[:, :, 1] .- [result.zero[:vl] result.zero[:vh]]) <= 1e-6 # hide
 nothing # hide
 ```
 
 The division of labor is deliberate: `EconPDEs.jl` solves the nonlinear policy problem;
 `InfinitesimalGenerators.jl` turns the solved law of motion into a linear generator and
-computes the invariant distribution.
+computes distributions and expectations under it.
 
 ## Writing the residual yourself
 
-`pdesolve` is a convenience layer. It creates the derivative bundle `u`, applies boundary
-conditions, assembles the vector residual, builds a sparse Jacobian pattern, and calls
-[`finiteschemesolve`](api.md). If you want a less magical version, you can skip `pdesolve`
-and write the vector residual directly.
-
-This is the same idea as the older Wang-Wang-Yang implementation:
+`pdesolve` is the high-level interface. It creates the derivative bundle `u`, applies
+boundary conditions, assembles the vector residual, builds a sparse Jacobian pattern, and
+calls [`finiteschemesolve`](api.md); see
+[Solving models](solving.md#Solver-and-troubleshooting) for the solver structure. If you
+want a lower-level version, you can skip `pdesolve` and construct each derivative yourself
+with `InfinitesimalGenerators.jl`'s `FirstDerivative`, writing directly into the residual
+array — here for the same two-income model, with the two value functions stored as the
+columns of a matrix:
 
 ```@example infinitesimal_generators
-function wang_wang_yang_residual!(pt, m, ws, p)
-    (; μ, σ, r, ρ, γ, ψ, wmin) = m
-
-    pw_up = FirstDerivative(ws, p; direction = :forward, bc = (1.0, 1.0))
-    pw_down = FirstDerivative(ws, p; direction = :backward, bc = (1.0, 1.0))
-    pww = SecondDerivative(ws, p; bc = (1.0, 1.0))
-
-    for i in eachindex(ws)
-        w = ws[i]
-        # Guard the policy implied by the FOC; Newton can try nonpositive marginal values.
-        cmax = 100.0 * (1 + max((r - μ + σ^2) * w, 0.0))
-
-        c_up = pw_up[i] > 0 ? min((r + ψ * (ρ - r)) * p[i] * pw_up[i]^(-ψ), cmax) : cmax
-        μw_up = (r - μ + σ^2) * w + 1 - c_up
-        if μw_up >= 0
-            pw = pw_up[i]
-        else
-            c_down = pw_down[i] > 0 ? min((r + ψ * (ρ - r)) * p[i] * pw_down[i]^(-ψ), cmax) : cmax
-            μw_down = (r - μ + σ^2) * w + 1 - c_down
-            if (μw_down <= 0) && (w > wmin)
-                pw = pw_down[i]
+function two_income_residual!(vt, m, as, v)
+    (; yl, yh, λlh, λhl, r, ρ, γ, amin) = m
+    for (j, y, λ) in ((1, yl, λlh), (2, yh, λhl))
+        k = 3 - j
+        va_up = FirstDerivative(as, view(v, :, j); direction = :forward, bc = (0, 0))
+        va_down = FirstDerivative(as, view(v, :, j); direction = :backward, bc = (0, 0))
+        for i in eachindex(as)
+            a = as[i]
+            # Guard the policy implied by the FOC; Newton can try nonpositive marginal values.
+            cmax = 100.0 * (y + r * max(a, 0.0))
+            c_up = va_up[i] > 0 ? min(va_up[i]^(-1 / γ), cmax) : cmax
+            μa_up = y + r * a - c_up
+            if μa_up >= 0.0
+                va, c, μa = va_up[i], c_up, μa_up
             else
-                c = 1 + (r - μ + σ^2) * w
-                pw = (c / ((r + ψ * (ρ - r)) * p[i]))^(-1 / ψ)
+                c_down = va_down[i] > 0 ? min(va_down[i]^(-1 / γ), cmax) : cmax
+                μa_down = y + r * a - c_down
+                if μa_down <= 0.0 && a > amin
+                    va, c, μa = va_down[i], c_down, μa_down
+                else
+                    c = y + r * a          # borrowing constraint binds: drift is zero
+                    μa = 0.0
+                    va = c^(-γ)
+                end
             end
+            vt[i, j] = -(c^(1 - γ) / (1 - γ) + μa * va + λ * (v[i, k] - v[i, j]) - ρ * v[i, j])
         end
-
-        pt[i] = -(
-            (((r + ψ * (ρ - r)) * pw^(1 - ψ) - ψ * ρ) / (ψ - 1) + μ - γ * σ^2 / 2) * p[i] +
-            ((r - μ + γ * σ^2) * w + 1) * pw +
-            σ^2 * w^2 / 2 * (pww[i] - γ * pw^2 / p[i])
-        )
     end
-    return pt
+    return vt
 end
 
-p, residual_norm = finiteschemesolve(
-    (ydot, y) -> wang_wang_yang_residual!(ydot, m, ws, y),
-    yend.p;
+v, residual_norm = finiteschemesolve(
+    (ydot, y) -> two_income_residual!(ydot, m, as, y),
+    [yend.vl yend.vh];
     verbose = false,
 )
 
-@assert residual_norm <= 1e-5 # hide
-@assert maximum(abs, p .- result.zero[:p]) <= 1e-4 # hide
+maximum(abs, v .- [result.zero[:vl] result.zero[:vh]])
+```
+
+```@example infinitesimal_generators
+@assert residual_norm <= 1e-6 # hide
+@assert maximum(abs, v .- [result.zero[:vl] result.zero[:vh]]) <= 1e-6 # hide
 nothing # hide
 ```
 
 This computes the same fixed point as the `pdesolve` version. The tradeoff is transparency
 for bookkeeping: you choose how to construct each derivative and write directly into the
-flat residual vector, but you also lose the named derivative bundle, automatic optional
-outputs, multidimensional stencil assembly, and the sparse Jacobian pattern that `pdesolve`
+residual array, but you also lose the named derivative bundle, automatic optional outputs,
+multidimensional stencil assembly, and the sparse Jacobian pattern that `pdesolve`
 constructs for one-, two-, and three-state problems.

--- a/docs/src/infinitesimal_generators.md
+++ b/docs/src/infinitesimal_generators.md
@@ -26,7 +26,7 @@ switches between ``y_l`` and ``y_h`` as a two-state Poisson process. The model d
 the one from the [example page](examples/consumption_saving/consumption_saving_two_income.md);
 the only thing that matters here is that the equation returns the policy-implied asset
 drifts `μla` and `μha` as
-[optional outputs](getting_started.md#Exploring-the-solution), so that `pdesolve` saves
+[saved objects](getting_started.md#Exploring-the-solution), so that `pdesolve` saves
 them on the grid:
 
 ```@example infinitesimal_generators
@@ -97,8 +97,8 @@ result = pdesolve(m, stategrid, yend; verbose = false)
 @assert result.residual_norm <= 1e-6 # hide
 
 as = stategrid[:a]
-μla = result.optional[:μla]
-μha = result.optional[:μha]
+μla = result.saved[:μla]
+μha = result.saved[:μha]
 nothing # hide
 ```
 
@@ -151,8 +151,8 @@ Low-income households dissave toward the borrowing limit; high-income households
 Any moment of the stationary distribution is now a weighted sum:
 
 ```@example infinitesimal_generators
-cl = result.optional[:cl]
-ch = result.optional[:ch]
+cl = result.saved[:cl]
+ch = result.saved[:ch]
 mean_assets = sum(g .* as)
 share_borrowers = sum(g[as .< 0, :])
 aggregate_consumption = sum(g .* [cl ch])
@@ -189,7 +189,7 @@ The two agree to solver tolerance, not just to discretization error. This is aga
 the two packages share the upwind convention: at convergence, the discretized HJB solved by
 `pdesolve` is exactly ``\rho v = u(c) + \mathbb{T} v`` where ``\mathbb{T}`` is
 `generator(X)`. If the recovered `V` were far from `result.zero`, it would flag an
-inconsistency — for example a drift saved in `optional` that does not match the upwind
+inconsistency — for example a drift saved in `result.saved` that does not match the upwind
 branch actually used in the equation.
 
 ```@example infinitesimal_generators
@@ -261,6 +261,6 @@ nothing # hide
 
 This computes the same fixed point as the `pdesolve` version. The tradeoff is transparency
 for bookkeeping: you choose how to construct each derivative and write directly into the
-residual array, but you also lose the named derivative bundle, automatic optional outputs,
+residual array, but you also lose the named derivative bundle, automatic saving of outputs,
 multidimensional stencil assembly, and the sparse Jacobian pattern that `pdesolve`
 constructs for one-, two-, and three-state problems.

--- a/docs/src/infinitesimal_generators.md
+++ b/docs/src/infinitesimal_generators.md
@@ -17,7 +17,11 @@ This page extends the short workflow in
 full version on the
 [consumption–saving model with two income states](examples/consumption_saving/consumption_saving_two_income.md):
 solve the coupled HJB with `pdesolve`, build the solved Markov process, compute the
-stationary wealth distribution, and check the solution with Feynman–Kac.
+stationary wealth distribution, and check the solution with Feynman–Kac. The
+[HJB tutorial in the InfinitesimalGenerators documentation](https://matthieugomez.github.io/InfinitesimalGenerators.jl/dev/hjb/)
+solves the *same model with the same parameters* from the opposite direction — building the
+implicit finite-difference method by hand from generator matrices, and ending with
+`pdesolve` — so the two pages can be read as mirrors of each other.
 
 ## From `pdesolve` to a Markov process
 
@@ -104,11 +108,11 @@ nothing # hide
 
 The solved model is a Markov process on `(a, y)`: income is a two-state Markov chain, and
 within each income state assets drift deterministically at the policy-implied rate. This is
-exactly what `SwitchingProcess` represents — a `MarkovChain` plus one continuous process per
+exactly what `SwitchingProcess` represents — a `ContinuousTimeMarkovChain` plus one continuous process per
 income state, here two `DiffusionProcess`es with zero volatility:
 
 ```@example infinitesimal_generators
-Z = MarkovChain([m.yl, m.yh], [-m.λlh m.λlh; m.λhl -m.λhl])
+Z = ContinuousTimeMarkovChain([m.yl, m.yh], [-m.λlh m.λlh; m.λhl -m.λhl])
 Xl = DiffusionProcess(as, μla, zeros(length(as)))
 Xh = DiffusionProcess(as, μha, zeros(length(as)))
 X = SwitchingProcess(Z, [Xl, Xh])
@@ -173,7 +177,10 @@ nothing # hide
 
 ## Checking the solution with Feynman–Kac
 
-`feynman_kac` computes conditional expectations under the solved process. A natural check:
+`feynman_kac` computes conditional expectations under the solved process — see the
+[expectations tutorial](https://matthieugomez.github.io/InfinitesimalGenerators.jl/dev/expectations/)
+in the InfinitesimalGenerators documentation for what it computes in general (forecasts,
+present values, state-dependent discounting). Here it gives a natural check:
 the expected discounted utility from following the solved policy,
 ``E[\int_0^\infty e^{-\rho t} u(c_t) \, dt \mid a_0, y_0]``, must reproduce the value
 function itself.
@@ -210,7 +217,10 @@ calls [`finiteschemesolve`](api.md); see
 want a lower-level version, you can skip `pdesolve` and construct each derivative yourself
 with `InfinitesimalGenerators.jl`'s `FirstDerivative`, writing directly into the residual
 array — here for the same two-income model, with the two value functions stored as the
-columns of a matrix:
+columns of a matrix. (The
+[HJB tutorial](https://matthieugomez.github.io/InfinitesimalGenerators.jl/dev/hjb/) in the
+InfinitesimalGenerators documentation shows the same construction driving the classic
+fixed-``\Delta`` linear iteration of Achdou et al. instead of `finiteschemesolve`.)
 
 ```@example infinitesimal_generators
 function two_income_residual!(vt, m, as, v)

--- a/docs/src/solving.md
+++ b/docs/src/solving.md
@@ -175,6 +175,10 @@ starts cautiously and adapts:
 3. If the inner Newton solve fails, shrink `Δ` by 10 and retry.
 4. Stop when the residual norm falls below `maxdist`.
 
+This adaptive scheme is *pseudo-transient continuation*, imported from computational fluid
+dynamics; formal convergence conditions are given in
+[Kelley and Keyes (1998)](https://doi.org/10.1137/S0036142996304796).
+
 The Jacobian is sparse because each finite-difference equation only depends on nearby grid
 points. For one-, two-, and three-state problems, `pdesolve` builds this sparsity pattern
 and computes the Jacobian by colored finite differences. This is why fine grids remain

--- a/examples/asset_pricing/brunnermeier_sannikov.jl
+++ b/examples/asset_pricing/brunnermeier_sannikov.jl
@@ -175,4 +175,4 @@ result = pdesolve((state, u) -> m(state, u, Δx, xmin), stategrid, yend; autodif
 # constraint slackens.
 
 xs = stategrid[:x]
-plot(xs, result.optional[:q]; xlabel = "experts' wealth share x", ylabel = "capital price q", legend = false)
+plot(xs, result.saved[:q]; xlabel = "experts' wealth share x", ylabel = "capital price q", legend = false)

--- a/examples/asset_pricing/garleanu_panageas.jl
+++ b/examples/asset_pricing/garleanu_panageas.jl
@@ -120,6 +120,6 @@ result = pdesolve(m, stategrid, yend)
 # borne more willingly when the less risk-averse agents are wealthier.
 
 xs = stategrid[:x]
-p1 = plot(xs, result.optional[:κ]; xlabel = "consumption share of bold agents x", ylabel = "price of risk κ", legend = false)
-p2 = plot(xs, result.optional[:r]; xlabel = "consumption share of bold agents x", ylabel = "interest rate r", legend = false)
+p1 = plot(xs, result.saved[:κ]; xlabel = "consumption share of bold agents x", ylabel = "price of risk κ", legend = false)
+p2 = plot(xs, result.saved[:r]; xlabel = "consumption share of bold agents x", ylabel = "interest rate r", legend = false)
 plot(p1, p2; layout = (1, 2), size = (800, 300))

--- a/examples/asset_pricing/gomez.jl
+++ b/examples/asset_pricing/gomez.jl
@@ -129,4 +129,4 @@ result = pdesolve(m, stategrid, yend)
 # ``x``.
 
 xs = stategrid[:x]
-plot(xs, result.optional[:σR]; xlabel = "entrepreneurs' consumption share x", ylabel = "return volatility σR", legend = false)
+plot(xs, result.saved[:σR]; xlabel = "entrepreneurs' consumption share x", ylabel = "return volatility σR", legend = false)

--- a/examples/asset_pricing/he_krishnamurthy.jl
+++ b/examples/asset_pricing/he_krishnamurthy.jl
@@ -105,4 +105,4 @@ result = pdesolve(m, stategrid, yend)
 # and the sector can absorb little risk.
 
 xs = stategrid[:x]
-plot(xs, result.optional[:κ]; xlabel = "specialists' wealth share x", ylabel = "price of risk κ", legend = false)
+plot(xs, result.saved[:κ]; xlabel = "specialists' wealth share x", ylabel = "price of risk κ", legend = false)

--- a/examples/consumption_saving/consumption_saving_diffusion_income.jl
+++ b/examples/consumption_saving/consumption_saving_diffusion_income.jl
@@ -113,8 +113,8 @@ as = stategrid[:a]
 ys = stategrid[:y]
 idx = 1:div(length(as), 3)          # left third of the asset grid, where the curvature is
 iys = round.(Int, range(1, length(ys), length = 3))
-μa = result.optional[:μa]
-c = result.optional[:c]
+μa = result.saved[:μa]
+c = result.saved[:c]
 
 p1 = plot(xlabel = "assets a", ylabel = "consumption c")
 for iy in iys

--- a/examples/consumption_saving/consumption_saving_risky_asset.jl
+++ b/examples/consumption_saving/consumption_saving_risky_asset.jl
@@ -202,11 +202,11 @@ iys = round.(Int, range(1, length(ys), length = 3))
 
 p1 = plot(xlabel = "wealth a", ylabel = "consumption c")
 for iy in iys
-    plot!(p1, as[idx], result.optional[:c][iy, idx], label = "y = $(round(ys[iy], digits = 2))")
+    plot!(p1, as[idx], result.saved[:c][iy, idx], label = "y = $(round(ys[iy], digits = 2))")
 end
 p2 = plot(xlabel = "wealth a", ylabel = "saving μa")
 for iy in iys
-    plot!(p2, as[idx], result.optional[:μa][iy, idx], label = "y = $(round(ys[iy], digits = 2))")
+    plot!(p2, as[idx], result.saved[:μa][iy, idx], label = "y = $(round(ys[iy], digits = 2))")
 end
 hline!(p2, [0.0]; color = :gray, linestyle = :dash, label = "")
 plot(p1, p2; layout = (1, 2), size = (800, 300))

--- a/examples/consumption_saving/consumption_saving_two_income.jl
+++ b/examples/consumption_saving/consumption_saving_two_income.jl
@@ -119,7 +119,7 @@ result = pdesolve(m, stategrid, yend)
 
 as = stategrid[:a]
 idx = 1:div(length(as), 3)          # left third of the asset grid, where the curvature is
-p1 = plot(as[idx], [result.optional[:cl][idx] result.optional[:ch][idx]]; label = ["low income" "high income"], xlabel = "assets a", ylabel = "consumption c(a)", legend = :bottomright)
-p2 = plot(as[idx], [result.optional[:μla][idx] result.optional[:μha][idx]]; label = ["low income" "high income"], xlabel = "assets a", ylabel = "saving μa(a)", legend = :topright)
+p1 = plot(as[idx], [result.saved[:cl][idx] result.saved[:ch][idx]]; label = ["low income" "high income"], xlabel = "assets a", ylabel = "consumption c(a)", legend = :bottomright)
+p2 = plot(as[idx], [result.saved[:μla][idx] result.saved[:μha][idx]]; label = ["low income" "high income"], xlabel = "assets a", ylabel = "saving μa(a)", legend = :topright)
 hline!(p2, [0.0]; color = :gray, linestyle = :dash, label = "")
 plot(p1, p2; layout = (1, 2), size = (800, 300))

--- a/examples/consumption_saving/wang_wang_yang.jl
+++ b/examples/consumption_saving/wang_wang_yang.jl
@@ -104,8 +104,8 @@ result = pdesolve(m, stategrid, yend, bc = (; pw = (1.0, 1.0)))
 
 ws = stategrid[:w]
 idx = 1:div(length(ws), 3)          # left third of the grid, where the curvature is
-p1 = plot(ws[idx], result.optional[:c][idx]; xlabel = "wealth-income ratio w", ylabel = "consumption c", legend = false)
-p2 = plot(ws[idx], result.optional[:μw][idx]; xlabel = "wealth-income ratio w", ylabel = "saving μw", legend = false)
+p1 = plot(ws[idx], result.saved[:c][idx]; xlabel = "wealth-income ratio w", ylabel = "consumption c", legend = false)
+p2 = plot(ws[idx], result.saved[:μw][idx]; xlabel = "wealth-income ratio w", ylabel = "saving μw", legend = false)
 hline!(p2, [0.0]; color = :gray, linestyle = :dash)
 plot(p1, p2; layout = (1, 2), size = (800, 300))
 

--- a/examples/corporate_finance/bolton_chen_wang.jl
+++ b/examples/corporate_finance/bolton_chen_wang.jl
@@ -84,7 +84,7 @@ result = pdesolve(m, stategrid, yend; bc = (; vw = (1.5, 1.0)))
 
 function f(m, x, stategrid, y)
   result = pdesolve(m, stategrid, y; bc = (; vw = (x[1], x[2])), verbose = false)
-  v, vw, w = result.optional[:v], result.optional[:vw], result.optional[:w]
+  v, vw, w = result.saved[:v], result.saved[:vw], result.saved[:w]
   out = zeros(2)
   mi = argmin(abs.(1 + m.γ .- vw))
   out[1] =  v[mi] - m.ϕ - (1 + m.γ) * w[mi] - v[1]
@@ -106,8 +106,8 @@ result = pdesolve(m, stategrid, yend; bc = (; vw = (newsol.zero[1], newsol.zero[
 # panels use the solution at the boundary slopes pinned down by `NLsolve`.
 
 ws = stategrid[:w]
-v = result.optional[:v]
-vw = result.optional[:vw]
+v = result.saved[:v]
+vw = result.saved[:vw]
 i = (v ./ vw .- ws .- 1) ./ m.θ
 p1 = plot(ws, v; xlabel = "cash–capital ratio w", ylabel = "firm value v(w)", legend = false)
 p2 = plot(ws, i; xlabel = "cash–capital ratio w", ylabel = "investment rate i(w)", legend = false)

--- a/examples/neoclassical_growth.jl
+++ b/examples/neoclassical_growth.jl
@@ -105,8 +105,8 @@ plot(ks, result.zero[:v]; xlabel = "capital k", ylabel = "value v(k)", legend = 
 # below the steady state and negative above it, crossing zero exactly at ``\bar k`` — the
 # saddle-path-stable steady state the economy is drawn toward.
 
-p1 = plot(ks, result.optional[:c]; xlabel = "capital k", ylabel = "consumption c(k)", legend = false)
-p2 = plot(ks, result.optional[:μk]; xlabel = "capital k", ylabel = "capital drift μk", legend = false)
+p1 = plot(ks, result.saved[:c]; xlabel = "capital k", ylabel = "consumption c(k)", legend = false)
+p2 = plot(ks, result.saved[:μk]; xlabel = "capital k", ylabel = "capital drift μk", legend = false)
 hline!(p2, [0.0]; color = :gray, linestyle = :dash)
 vline!(p2, [k̄]; color = :red, linestyle = :dot)
 plot(p1, p2; layout = (1, 2), size = (800, 300))

--- a/src/EconPDEs.jl
+++ b/src/EconPDEs.jl
@@ -24,13 +24,23 @@ The value returned by `pdesolve`, with fields:
 * `zero`: the solved unknown functions (an `OrderedDict`, or a vector of them for a
   time-dependent problem).
 * `residual_norm`: the norm of the residual at the solution.
-* `optional`: the extra objects saved by the PDE function, together with the solved unknowns.
+* `saved`: objects saved by the PDE function, together with the solved unknowns.
+
+For backward compatibility, `result.optional` is an alias for `result.saved`.
 """
 struct EconPDEResult{Z, R, O}
 	zero::Z 			# solution
 	residual_norm::R   # norm of ydot for solution
-	optional::O        # Optional terms returned in the third argument of the function passed to pdesolve
+	saved::O           # Objects returned in the second NamedTuple of the PDE function
 end
+
+function Base.getproperty(x::EconPDEResult, name::Symbol)
+    name === :optional && return getfield(x, :saved)
+    return getfield(x, name)
+end
+
+Base.propertynames(x::EconPDEResult, private::Bool = false) =
+    private ? (:zero, :residual_norm, :saved, :optional) : (:zero, :residual_norm, :saved)
 
 # Compact display: solution arrays can hold hundreds of thousands of entries,
 # so print names and sizes rather than the arrays themselves.
@@ -41,15 +51,15 @@ function Base.show(io::IO, x::EconPDEResult)
         # time-dependent solve: one solution per time
         println(io, "EconPDEResult (time-dependent, ", length(x.zero), " times)")
         println(io, "  zero:          ", _summarize_names(first(x.zero)), " at each time")
-        if x.optional !== nothing
-            println(io, "  optional:      ", join(keys(first(x.optional)), ", "), " at each time")
+        if x.saved !== nothing
+            println(io, "  saved:         ", join(keys(first(x.saved)), ", "), " at each time")
         end
         print(io, "  residual_norm: ", maximum(x.residual_norm), " (max over times)")
     else
         println(io, "EconPDEResult")
         println(io, "  zero:          ", _summarize_names(x.zero))
-        if x.optional !== nothing
-            println(io, "  optional:      ", join(keys(x.optional), ", "))
+        if x.saved !== nothing
+            println(io, "  saved:         ", join(keys(x.saved), ", "))
         end
         print(io, "  residual_norm: ", x.residual_norm)
     end
@@ -63,7 +73,7 @@ function Base.iterate(x::EconPDEResult, state = 1)
 	elseif state == 2
 		return (x.residual_norm, 3)
 	elseif state == 3
-		return (x.optional, 4)
+		return (x.saved, 4)
 	end
 end
 

--- a/src/pdesolve.jl
+++ b/src/pdesolve.jl
@@ -12,8 +12,8 @@ state grid of one, two, or three state variables.
     - `u` is a `NamedTuple` with each unknown function and its finite-difference derivatives
       at that point (e.g. `v`, `vk_up`, `vk_down`, `vkk`, …),
     - `out` is a `NamedTuple` with one time derivative per unknown (e.g. `(; vt)`).
-  `f` may also return a second `NamedTuple` of extra objects to save on the grid; these are
-  returned in `result.optional`.
+  `f` may also return a second `NamedTuple` of objects to save on the grid; these are
+  returned in `result.saved`.
 * `grid`: a `NamedTuple` (or `OrderedDict`) mapping each state variable name to an
   `AbstractVector` (its grid), e.g. `(; k = range(...))`.
 * `yend`: a `NamedTuple` (or `OrderedDict`) mapping each unknown name to an array of initial
@@ -51,7 +51,8 @@ state grid of one, two, or three state variables.
 * `monotonicity_max_warnings`: maximum number of monotonicity warnings to print. Defaults to 5.
 
 Returns an `EconPDEResult` with fields `zero` (the solved unknowns), `residual_norm`,
-and `optional` (the saved objects, together with the solved unknowns).
+and `saved` (the saved objects, together with the solved unknowns). `result.optional`
+is kept as a backward-compatible alias for `result.saved`.
 """
 function pdesolve(apm, @nospecialize(grid), @nospecialize(yend), τs::Union{Nothing, AbstractVector} = nothing; is_algebraic = nothing, bc = nothing, verbose = true, check_monotonicity = false, monotonicity_tol = 1e-6, monotonicity_max_warnings = 5, kwargs...)
     # `grid`, `yend`, `is_algebraic`, and `bc` may be passed either as an OrderedDict or as a

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -41,8 +41,8 @@ end
     @test result.residual_norm <= 1e-6
 
     v = result.zero[:v]
-    c = result.optional[:c]
-    μk = result.optional[:μk]
+    c = result.saved[:c]
+    μk = result.saved[:μk]
     @test size(v) == size(grid.k)
     @test size(c) == size(grid.k)
     # value increasing and concave, consumption increasing
@@ -53,13 +53,17 @@ end
     icross = findfirst(<(0), μk)
     @test icross !== nothing
     @test abs(grid.k[icross] - kbar) < 0.05 * kbar
-    # optional also contains the solved unknowns
-    @test result.optional[:v] == v
+    # saved also contains the solved unknowns
+    @test result.saved[:v] == v
+    @test result.optional === result.saved
+    @test :saved in propertynames(result)
+    @test :optional in propertynames(result, true)
 
     # legacy tuple destructuring still works
-    y, residual_norm, optional = result
+    y, residual_norm, saved = result
     @test y === result.zero
     @test residual_norm === result.residual_norm
+    @test saved === result.saved
 
     # compact show: names and sizes, not the arrays
     str = sprint(show, result)
@@ -90,7 +94,8 @@ end
     @test length(result.zero) == length(τs)
     @test result.zero[end][:v] == collect(guess.v)   # terminal condition
     @test maximum(result.residual_norm[2:end]) <= 1e-6
-    @test size(result.optional[1][:c]) == size(grid.k)
+    @test size(result.saved[1][:c]) == size(grid.k)
+    @test result.optional === result.saved
 
     # three-argument function: time-varying equation is detected and used
     ts_seen = Float64[]


### PR DESCRIPTION
Follow-up docs/API cleanup:

- Rename saved PDE outputs to `result.saved` while keeping `result.optional` as a compatibility alias
- Reframe solution exploration around saved policies and drifts
- Expand the InfinitesimalGenerators page around stationary distributions and Feynman-Kac checks
- Update README and examples to use the new name