### PR TITLE
Harden monotonicity diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Build status](https://github.com/matthieugomez/EconPDEs.jl/workflows/CI/badge.svg)](https://github.com/matthieugomez/EconPDEs.jl/actions)
 [![Coverage Status](http://codecov.io/github/matthieugomez/EconPDEs.jl/coverage.svg?branch=main)](http://codecov.io/github/matthieugomez/EconPDEs.jl/?branch=main)
+[![Stable Docs](https://img.shields.io/badge/docs-stable-blue.svg)](https://www.matthieugomez.com/EconPDEs.jl/stable/)
 [![Docs](https://img.shields.io/badge/docs-dev-blue.svg)](https://www.matthieugomez.com/EconPDEs.jl/dev/)
 
 # EconPDEs.jl

--- a/src/finiteschemesolve.jl
+++ b/src/finiteschemesolve.jl
@@ -21,7 +21,7 @@ function implicit_timestep(G!, ypost, Δ; is_algebraic = fill(false, size(ypost)
         fdcache = JacobianCache(ypost, fdtype, eltype(ypost); colorvec = colorvec, sparsity = J0c)
         function jac!(J, y)
             finite_difference_jacobian!(J, G_helper!, y, fdcache)
-            _run_monotonicity_check!(monotonicity_check, J, y, Δ, is_algebraic)
+            _try_run_monotonicity_check!(monotonicity_check, J, y, Δ, is_algebraic)
             return J
         end
         jac = jac!

--- a/src/monotonicity.jl
+++ b/src/monotonicity.jl
@@ -8,6 +8,7 @@ mutable struct MonotonicityChecker
     suppressed::Bool
     check_stencils::Bool
     sign_checked::Bool
+    disabled::Bool
 end
 
 function MonotonicityChecker(stategrid::StateGrid, @nospecialize(guess); tol = 1e-6, max_warnings = 5, check_stencils = true)
@@ -21,6 +22,7 @@ function MonotonicityChecker(stategrid::StateGrid, @nospecialize(guess); tol = 1
         false,
         check_stencils,
         false,
+        false,
     )
 end
 
@@ -28,6 +30,18 @@ _run_monotonicity_check!(::Nothing, J, y, Δ, is_algebraic) = nothing
 function _run_monotonicity_check!(checker::MonotonicityChecker, J, y, Δ, is_algebraic)
     _check_sign_convention!(checker, J, Δ, is_algebraic)
     checker.check_stencils && _check_monotonicity!(checker, J)
+    return nothing
+end
+
+_try_run_monotonicity_check!(::Nothing, J, y, Δ, is_algebraic) = nothing
+function _try_run_monotonicity_check!(checker::MonotonicityChecker, J, y, Δ, is_algebraic)
+    checker.disabled && return nothing
+    try
+        _run_monotonicity_check!(checker, J, y, Δ, is_algebraic)
+    catch err
+        checker.disabled = true
+        @debug "Monotonicity diagnostic failed; continuing without diagnostics" exception = (err, catch_backtrace())
+    end
     return nothing
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using Test
 using Logging
+using SparseArrays
 using EconPDEs
 
 #========================================================================================
@@ -182,6 +183,10 @@ end
     end
 
     @test_logs min_level=Logging.Warn pdesolve(correct_upwind, grid_good, y_good; Δ = Inf, iterations = 1, verbose = false, check_monotonicity = true)
+
+    checker = EconPDEs.MonotonicityChecker(EconPDEs.StateGrid((; x = range(0.0, 1.0, length = 2))), (; V = ones(2)))
+    @test EconPDEs._try_run_monotonicity_check!(checker, spzeros(2, 2), zeros(2), 1.0, Bool[]) === nothing
+    @test checker.disabled
 end
 
 @testset "Sign-convention diagnostic" begin
@@ -195,7 +200,7 @@ end
         return (; Vt)
     end
 
-    @test_logs (:warn, r"negative diagonal at every grid point") pdesolve(flipped_sign, grid, y0; iterations = 1, verbose = false)
+    @test_logs (:warn, r"negative diagonal at every grid point") pdesolve(flipped_sign, grid, y0; Δ = 0.5, iterations = 1, verbose = false)
 
     # the correct convention triggers no warning under the default (finite Δ) solve
     function correct_sign(state, y)


### PR DESCRIPTION
Make monotonicity diagnostics best-effort so a checker failure cannot abort a solve. Also avoid the singular `Δ = 1` case in the sign-convention test and add a stable docs badge.