### PR TITLE
Simplify docs framing

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -40,18 +40,13 @@ finite-difference residuals.
 Julia already has good PDE packages. `EconPDEs.jl` has a narrower goal: solve the
 continuous-time HJBs that come up in economic models.
 
-In these models, the PDE is usually tied to an optimal policy. The policy depends on the
-value function, and the value function depends on the policy. That feedback is the part
-that general PDE interfaces often do not make convenient.
+These equations have a structure that is easy to lose in a generic PDE interface. The
+state drift and volatility are often chosen by the agent, so the differential operator
+depends on the current guess for the value function. At the same time, the equation is
+strongly forward-looking: today's value depends on future values, future policies, and the
+way the state distribution moves under those policies.
 
-| Economic HJBs need | What this means in practice |
-| --- | --- |
-| Infinitesimal generators | The operator describes how the state moves locally: drift times the first derivative plus volatility squared times the second derivative. The companion package [InfinitesimalGenerators.jl](https://github.com/matthieugomez/InfinitesimalGenerators.jl) works with these operators directly; see [InfinitesimalGenerators](infinitesimal_generators.md). |
-| Policies inside the equation | Drift, diffusion, controls, and nonlinear terms can depend on the current guess for the value function. You write these terms directly, in the same place as the policy rule. |
-| Upwinding by drift sign | The first derivative must be taken from the right side. If the drift changes during the solve, the stencil changes too. See [Writing the PDE function](pde_function.md#Upwinding). |
-| Economic boundaries | Borrowing limits, reflecting states, and degenerate diffusions are not just Dirichlet or periodic boundary conditions. See [Boundary conditions](boundary_conditions.md). |
-| Stationary nonlinear solves | Sparse finite-difference Jacobians and continuation make fine grids practical. See [Solver and troubleshooting](solver.md). |
-
-`EconPDEs.jl` handles those details so the model code can stay close to the economics:
-write the local equation, and the package builds the derivatives, boundary treatment,
-upwinding, and nonlinear solve.
+`EconPDEs.jl` keeps that feedback loop explicit. You write the local economic equation,
+including the policy rules and the implied drift or volatility. The package then builds the
+finite-difference derivatives, boundary treatment, sparse Jacobian, and nonlinear solve
+needed to turn that equation into a stationary or time-dependent solution.

--- a/docs/src/infinitesimal_generators.md
+++ b/docs/src/infinitesimal_generators.md
@@ -125,7 +125,7 @@ size(X)
 the drift is positive, backward where it is negative, with the same default
 [reflecting boundaries](boundary_conditions.md)). That consistency matters below.
 
-## Stationary distribution
+### Stationary distribution
 
 The stationary distribution solves the Kolmogorov forward equation — the left null vector of
 the generator. `stationary_distribution` returns the probability mass at each grid point,


### PR DESCRIPTION
Tone down the Why EconPDEs section and nest the stationary-distribution material under the Markov-process section so the InfinitesimalGenerators page has two top-level sections.